### PR TITLE
add height info to add->Txs in api 

### DIFF
--- a/src/main/scala/com/wavesplatform/state2/reader/StateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/StateReader.scala
@@ -85,8 +85,9 @@ object StateReader {
 
     def included(signature: ByteStr): Option[Int] = s.transactionInfo(signature).map(_._1)
 
-    def accountTransactions(account: Address, limit: Int): Seq[_ <: ProcessedTransaction] = s.read { _ =>
-      s.accountTransactionIds(account, limit).flatMap(s.transactionInfo).map(_._2)
+    def accountTransactions(account: Address, limit: Int): Seq[(Int, _ <: ProcessedTransaction)] = s.read { _ =>
+      s.accountTransactionIds(account, limit)
+        .flatMap(s.transactionInfo)
     }
 
     def balance(account: Address): Long = s.accountPortfolio(account).balance

--- a/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
@@ -54,7 +54,10 @@ case class TransactionsApiRoute(
               path(Segment) { limitStr =>
                 Exception.allCatch.opt(limitStr.toInt) match {
                   case Some(limit) if limit > 0 && limit <= MaxTransactionsPerRequest =>
-                    complete(Json.arr(JsArray(state.accountTransactions(a, limit).map(processedTxToExtendedJson))))
+                    complete(Json.arr(JsArray(state.accountTransactions(a, limit).map{ case (h, tx) =>
+                      processedTxToExtendedJson(tx) + ("height" -> JsNumber(h))
+                    }
+                    )))
                   case Some(limit) if limit > MaxTransactionsPerRequest =>
                     complete(TooBigArrayAllocation)
                   case _ =>

--- a/src/test/scala/com/wavesplatform/state2/reader/StateReaderLastTransactionsTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/reader/StateReaderLastTransactionsTest.scala
@@ -34,12 +34,12 @@ class StateReaderLastTransactionsTest extends PropSpec with PropertyChecks with 
       assertDiffAndState(Seq(TestBlock.create(pre)), TestBlock.create(Seq(payment))) { (blockDiff, newState) =>
 
         val sender = EllipticCurve25519Proof.fromBytes(payment.proofs.proofs.head.bytes.arr).toOption.get.publicKey
-        newState.accountTransactions(sender, 1) shouldBe Seq(txToProcessedTx(payment))
+        newState.accountTransactions(sender, 1).map{case (h,tx) => tx} shouldBe Seq(txToProcessedTx(payment))
         val g = pre.head
         val tx1 = pre(1)
         val tx2 = pre(2)
-        newState.accountTransactions(sender, 3) shouldBe Seq(txToProcessedTx(payment), txToProcessedTx(tx2), txToProcessedTx(tx1))
-        newState.accountTransactions(sender, 10) shouldBe Seq(txToProcessedTx(payment), txToProcessedTx(tx2), txToProcessedTx(tx1), txToProcessedTx(g))
+        newState.accountTransactions(sender, 3).map{case (h,tx) => tx} shouldBe Seq(txToProcessedTx(payment), txToProcessedTx(tx2), txToProcessedTx(tx1))
+        newState.accountTransactions(sender, 10).map{case (h,tx) => tx} shouldBe Seq(txToProcessedTx(payment), txToProcessedTx(tx2), txToProcessedTx(tx1), txToProcessedTx(g))
       }
     }
   }


### PR DESCRIPTION
add height info to add->Txs in api 
unit test passed
```scala
[info] ScalaTest
[info] Run completed in 49 seconds, 917 milliseconds.
[info] Total number of tests run: 322
[info] Suites: completed 101, aborted 0
[info] Tests: succeeded 322, failed 0, canceled 0, ignored 14, pending 2
[info] All tests passed.
[info] Passed: Total 322, Failed 0, Errors 0, Passed 322, Ignored 14, Pending 2
[success] Total time: 52 s, completed Dec 19, 2018 12:37:47 PM
```
local test passed
`api/transactions/address/ARPnxBFbMzQQn4SncJ2WdH61ynqcPcninV4/limit/100`
```json
[ [ {
  "type" : 3,
  "id" : "H6XWnZccKoBCXgAvdBz4WHjVB1ujy57QD8WZZpBQW4Di",
  "fee" : 10000000,
  "timestamp" : 1543563102388000000,
  "proofs" : [ {
    "proofType" : "Curve25519",
    "publicKey" : "GcS3JZQXgJGi7R3QfAFp5BME4DwsnEC5cF1RTXSAGoq4",
    "signature" : "4wJvvYWffBe3W4994TfWDhqStBg9faNvBRvEjw5qQZBYs2ToMfSVB1wy6tz28iNwqVTnGG77MhYBDCaKcfWZnuTe"
  } ],
  "amount" : 1500000000000000,
  "recipient" : "ARPnxBFbMzQQn4SncJ2WdH61ynqcPcninV4",
  "feeScale" : 100,
  "status" : "Success",
  "feeCharged" : 10000000,
  "height" : 63382
}, {
  "type" : 1,
  "id" : "7ZcqaLEjb8vadao9sPcmbnFTHy2UBPw8ndBXPe6rEGWv",
  "fee" : 0,
  "slotId" : 56,
  "timestamp" : 1543286357457333127,
  "signature" : "4mTyNm9kPyA8j2n1JvE6bmhp3URge1fHwujdmy1kxrRREzmJjZTrUU241Q59muZT1TGo58gXed1scPaD24VAoGTx",
  "recipient" : "ARPnxBFbMzQQn4SncJ2WdH61ynqcPcninV4",
  "amount" : 0,
  "status" : "Success",
  "feeCharged" : 0,
  "height" : 1
} ] ]
```