### PR TITLE
update slot address related state setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ enablePlugins(sbtdocker.DockerPlugin, JavaServerAppPackaging, JDebPackaging, Sys
 
 name := "vsys"
 organization := "systems.v"
-version := "0.1.0"
+version := "0.1.1"
 scalaVersion in ThisBuild := "2.12.6"
 crossPaths := false
 publishArtifact in (Compile, packageDoc) := false

--- a/src/main/scala/com/wavesplatform/mining/Miner.scala
+++ b/src/main/scala/com/wavesplatform/mining/Miner.scala
@@ -59,10 +59,11 @@ class Miner(
       s"BlockChain is too old (last block ${parent.uniqueId} generated $blockAge ago)"
     ))
 
-  private def checkSlot(account:PrivateKeyAccount): Either[String,Int] =
-    Either.cond(stateReader.addressToSlotID(account.address).isDefined,
-      stateReader.addressToSlotID(account.address).get,
-      s"Address ${account.address} is not in Slot List.")
+  private def checkSlot(account:PrivateKeyAccount): Either[String, Int] = {
+    val slotID = stateReader.addressSlot(account.address)
+    Either.cond(slotID.isDefined && stateReader.slotAddress(slotID.get).get == account.address,
+      slotID.get, s"Address ${account.address} is not in Slot List.")
+  }
 
   private def generateOneBlockTask(account: PrivateKeyAccount, parentHeight: Int, parent: Block,
                                    greatGrandParent: Option[Block], balance: Long, mintTime: Long)(delay: FiniteDuration): Task[Either[String, Block]] = Task {

--- a/src/main/scala/com/wavesplatform/state2/Diff.scala
+++ b/src/main/scala/com/wavesplatform/state2/Diff.scala
@@ -45,8 +45,8 @@ case class Diff(transactions: Map[ByteStr, (Int, ProcessedTransaction, Set[Addre
                 portfolios: Map[Address, Portfolio],
                 issuedAssets: Map[ByteStr, AssetInfo],
                 aliases: Map[Alias, Address],
-                slotids: Map[Int, String],
-                addToSlot: Map[String, Int],
+                slotids: Map[Int, Option[String]],
+                addToSlot: Map[String, Option[Int]],
                 slotNum: Int,
                 txStatus: TransactionStatus.Value,
                 chargedFee: Long,
@@ -72,8 +72,8 @@ object Diff {
             portfolios: Map[Address, Portfolio] = Map.empty,
             assetInfos: Map[ByteStr, AssetInfo] = Map.empty,
             aliases: Map[Alias, Address] = Map.empty,
-            slotids: Map[Int,String] = Map.empty,
-            addToSlot: Map[String, Int] = Map.empty,
+            slotids: Map[Int, Option[String]] = Map.empty,
+            addToSlot: Map[String, Option[Int]] = Map.empty,
             slotNum: Int = 0,
             txStatus: TransactionStatus.Value = TransactionStatus.Success,
             chargedFee: Long = 0,
@@ -95,7 +95,7 @@ object Diff {
     orderFills = orderFills,
     leaseState = leaseState)
 
-  val empty = new Diff(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty,0, TransactionStatus.Unprocessed, 0L, Map.empty, Map.empty, Map.empty, Map.empty)
+  val empty = new Diff(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, 0, TransactionStatus.Unprocessed, 0L, Map.empty, Map.empty, Map.empty, Map.empty)
 
   implicit class DiffExt(d: Diff) {
     def asBlockDiff: BlockDiff = BlockDiff(d, 0, Map.empty)

--- a/src/main/scala/com/wavesplatform/state2/Diff.scala
+++ b/src/main/scala/com/wavesplatform/state2/Diff.scala
@@ -45,7 +45,8 @@ case class Diff(transactions: Map[ByteStr, (Int, ProcessedTransaction, Set[Addre
                 portfolios: Map[Address, Portfolio],
                 issuedAssets: Map[ByteStr, AssetInfo],
                 aliases: Map[Alias, Address],
-                slotids: Map[Int,String],
+                slotids: Map[Int, String],
+                addToSlot: Map[String, Int],
                 slotNum: Int,
                 txStatus: TransactionStatus.Value,
                 chargedFee: Long,
@@ -72,6 +73,7 @@ object Diff {
             assetInfos: Map[ByteStr, AssetInfo] = Map.empty,
             aliases: Map[Alias, Address] = Map.empty,
             slotids: Map[Int,String] = Map.empty,
+            addToSlot: Map[String, Int] = Map.empty,
             slotNum: Int = 0,
             txStatus: TransactionStatus.Value = TransactionStatus.Success,
             chargedFee: Long = 0,
@@ -84,6 +86,7 @@ object Diff {
     issuedAssets = assetInfos,
     aliases = aliases,
     slotids = slotids,
+    addToSlot = addToSlot,
     slotNum = slotNum,
     txStatus = txStatus,
     chargedFee = chargedFee,
@@ -92,7 +95,7 @@ object Diff {
     orderFills = orderFills,
     leaseState = leaseState)
 
-  val empty = new Diff(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, 0, TransactionStatus.Unprocessed, 0L, Map.empty, Map.empty, Map.empty, Map.empty)
+  val empty = new Diff(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty,0, TransactionStatus.Unprocessed, 0L, Map.empty, Map.empty, Map.empty, Map.empty)
 
   implicit class DiffExt(d: Diff) {
     def asBlockDiff: BlockDiff = BlockDiff(d, 0, Map.empty)
@@ -107,6 +110,7 @@ object Diff {
       issuedAssets = older.issuedAssets.combine(newer.issuedAssets),
       aliases = older.aliases ++ newer.aliases,
       slotids = older.slotids ++ newer.slotids,
+      addToSlot = older.addToSlot ++ newer.addToSlot,
       slotNum = older.slotNum + newer.slotNum,
       txStatus = newer.txStatus,
       chargedFee = newer.chargedFee,

--- a/src/main/scala/com/wavesplatform/state2/StateStorage.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateStorage.scala
@@ -30,19 +30,17 @@ class StateStorage private(file: Option[File]) extends AutoCloseable {
 
   val addressToID: MVMap[String, Int] = db.openMap("addressToID")
 
-  def setSlotAddress(i: Int, add: String):Unit = {
-    addressList.put(i,add)
-    addressToID.put(add,i)
-  }
+  def setSlotAddress(i: Int, add: String): Unit = addressList.put(i,add)
+
+  def setAddressSlot(add: String, i: Int): Unit = addressToID.put(add,i)
 
   def getSlotAddress(i: Int): Option[String] = Option(addressList.get(i))
 
-  def releaseSlotAddress(i: Int): Unit = {
-    addressToID.remove(addressList.get(i))
-    addressList.remove(i)
-  }
+  def getAddressSlot(add: String): Option[Int] = Option(addressToID.get(add))
 
-  def addressToSlotID(add: String): Option[Int] = Option(addressToID.get(add))
+  def releaseSlotAddress(i: Int): Unit = addressList.remove(i)
+
+  def releaseAddressSlot(add: String): Unit = addressToID.remove(add)
 
   def getEffectiveSlotAddressSize: Int = addressList.size()
 

--- a/src/main/scala/com/wavesplatform/state2/StateWriter.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateWriter.scala
@@ -113,17 +113,17 @@ class StateWriterImpl(p: StateStorage, synchronizationToken: ReentrantReadWriteL
     // if the blockDiff has contend/release transaction issued, change the slot address
     measureSizeLog("slotids_info")(blockDiff.txsDiff.slotids)(
       _.foreach {
-        case (id, acc) => acc.length match {
-          case 0 => sp().releaseSlotAddress(id)
-          case _ => sp().setSlotAddress(id, acc)
+        case (id, acc) => acc match {
+          case None => sp().releaseSlotAddress(id)
+          case _ => sp().setSlotAddress(id, acc.get)
         }
       })
 
     measureSizeLog("address to slot_info")(blockDiff.txsDiff.addToSlot)(
       _.foreach {
         case (acc, id) => id match {
-          case -1 => sp().releaseAddressSlot(acc)
-          case _ => sp().setAddressSlot(acc, id)
+          case None => sp().releaseAddressSlot(acc)
+          case _ => sp().setAddressSlot(acc, id.get)
         }
       })
 

--- a/src/main/scala/com/wavesplatform/state2/StateWriter.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateWriter.scala
@@ -115,7 +115,15 @@ class StateWriterImpl(p: StateStorage, synchronizationToken: ReentrantReadWriteL
       _.foreach {
         case (id, acc) => acc.length match {
           case 0 => sp().releaseSlotAddress(id)
-          case _ => sp ().setSlotAddress (id, acc)
+          case _ => sp().setSlotAddress(id, acc)
+        }
+      })
+
+    measureSizeLog("address to slot_info")(blockDiff.txsDiff.addToSlot)(
+      _.foreach {
+        case (acc, id) => id match {
+          case -1 => sp().releaseAddressSlot(acc)
+          case _ => sp().setAddressSlot(acc, id)
         }
       })
 

--- a/src/main/scala/com/wavesplatform/state2/diffs/ContendSlotsTransactionDiff.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/ContendSlotsTransactionDiff.scala
@@ -20,7 +20,7 @@ object ContendSlotsTransactionDiff {
     val sender = EllipticCurve25519Proof.fromBytes(tx.proofs.proofs.head.bytes.arr).toOption.get.publicKey
     val proofLength = tx.proofs.proofs.length
 
-    val multiSlotsCheck = s.addressToSlotID(sender.address) match {
+    val multiSlotsCheck = s.addressSlot(sender.address) match {
       case None => false
       case _ => true
     }
@@ -51,6 +51,7 @@ object ContendSlotsTransactionDiff {
           Right(Diff(height = height, tx = tx,
             portfolios = Map(sender.toAddress -> Portfolio(-tx.fee, LeaseInfo.empty, Map.empty)),
             slotids = Map(tx.slotId -> sender.toAddress.address),
+            addToSlot = Map(sender.toAddress.address -> tx.slotId),
             slotNum = 1,
             chargedFee = tx.fee))
         }
@@ -65,7 +66,7 @@ object ContendSlotsTransactionDiff {
       }
     }
     else if (multiSlotsCheck){
-      Left(GenericError(s"${sender.address} already own one slot."))
+      Left(GenericError(s"${sender.address} already owned one slot or contended by other node"))
     }
     else{
       Left(ValidationError.InvalidSlotId(tx.slotId))

--- a/src/main/scala/com/wavesplatform/state2/diffs/ContendSlotsTransactionDiff.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/ContendSlotsTransactionDiff.scala
@@ -41,10 +41,10 @@ object ContendSlotsTransactionDiff {
       }
       else {
         val contendGen = mintingBalance(s, fs, sender.toAddress, height)
-        val slotGen = s.slotAddress(tx.slotId) match {
+        val (slotGen, slotIncrease) = s.slotAddress(tx.slotId) match {
           //if the slot is occupied, return the generating balance, else return 0
-          case Some(l) => Address.fromString(l).right.map(arr => mintingBalance(s, fs, arr, height)).getOrElse(0L)
-          case None => 0L //here 0 can be changed to min contend cost
+          case Some(l) => (Address.fromString(l).right.map(arr => mintingBalance(s, fs, arr, height)).getOrElse(0L), 0)
+          case None => (0L, 1) //here 0 can be changed to min contend MAB
         }
         if (contendGen > slotGen) {
           // charge transaction fee and contend the slot
@@ -52,7 +52,7 @@ object ContendSlotsTransactionDiff {
             portfolios = Map(sender.toAddress -> Portfolio(-tx.fee, LeaseInfo.empty, Map.empty)),
             slotids = Map(tx.slotId -> sender.toAddress.address),
             addToSlot = Map(sender.toAddress.address -> tx.slotId),
-            slotNum = 1,
+            slotNum = slotIncrease,
             chargedFee = tx.fee))
         }
         else {

--- a/src/main/scala/com/wavesplatform/state2/diffs/ContendSlotsTransactionDiff.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/ContendSlotsTransactionDiff.scala
@@ -50,8 +50,8 @@ object ContendSlotsTransactionDiff {
           // charge transaction fee and contend the slot
           Right(Diff(height = height, tx = tx,
             portfolios = Map(sender.toAddress -> Portfolio(-tx.fee, LeaseInfo.empty, Map.empty)),
-            slotids = Map(tx.slotId -> sender.toAddress.address),
-            addToSlot = Map(sender.toAddress.address -> tx.slotId),
+            slotids = Map(tx.slotId -> Option(sender.toAddress.address)),
+            addToSlot = Map(sender.toAddress.address -> Option(tx.slotId)),
             slotNum = slotIncrease,
             chargedFee = tx.fee))
         }

--- a/src/main/scala/com/wavesplatform/state2/diffs/GenesisTransactionDiff.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/GenesisTransactionDiff.scala
@@ -16,7 +16,8 @@ object GenesisTransactionDiff {
           balance = tx.amount,
           LeaseInfo.empty,
           assets = Map.empty)),
-        slotids = Map(tx.slotId -> tx.recipient.address),
+        slotids = Map(tx.slotId -> Option(tx.recipient.address)),
+        addToSlot = Map(tx.recipient.address -> Option(tx.slotId)),
         slotNum = 1
       ))
     else

--- a/src/main/scala/com/wavesplatform/state2/diffs/ReleaseSlotsTransactionDiff.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/ReleaseSlotsTransactionDiff.scala
@@ -38,7 +38,9 @@ object ReleaseSlotsTransactionDiff {
     else if (hasEnoughMiner && isValidAddress && isValidSlotID) {
       Right(Diff(height = height, tx = tx,
         portfolios = Map(sender.toAddress -> Portfolio(-tx.fee, LeaseInfo.empty, Map.empty)),
-        slotids = Map(tx.slotId -> emptyAddress),slotNum = -1, chargedFee = tx.fee))
+        slotids = Map(tx.slotId -> emptyAddress),
+        addToSlot = Map(sender.toAddress.address -> -1),
+        slotNum = -1, chargedFee = tx.fee))
     }
     else if (!isValidSlotID){
       Left(ValidationError.InvalidSlotId(tx.slotId))

--- a/src/main/scala/com/wavesplatform/state2/diffs/ReleaseSlotsTransactionDiff.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/ReleaseSlotsTransactionDiff.scala
@@ -31,15 +31,14 @@ object ReleaseSlotsTransactionDiff {
 
     // add more ValidationError
 
-    val emptyAddress = ""
     if (proofLength > Proofs.MaxProofs){
       Left(GenericError(s"Too many proofs, max ${Proofs.MaxProofs} proofs"))
     }
     else if (hasEnoughMiner && isValidAddress && isValidSlotID) {
       Right(Diff(height = height, tx = tx,
         portfolios = Map(sender.toAddress -> Portfolio(-tx.fee, LeaseInfo.empty, Map.empty)),
-        slotids = Map(tx.slotId -> emptyAddress),
-        addToSlot = Map(sender.toAddress.address -> -1),
+        slotids = Map(tx.slotId -> None),
+        addToSlot = Map(sender.toAddress.address -> None),
         slotNum = -1, chargedFee = tx.fee))
     }
     else if (!isValidSlotID){

--- a/src/main/scala/com/wavesplatform/state2/patch/LeasePatch.scala
+++ b/src/main/scala/com/wavesplatform/state2/patch/LeasePatch.scala
@@ -19,6 +19,7 @@ object LeasePatch {
       issuedAssets = Map.empty,
       aliases = Map.empty,
       slotids = Map.empty,
+      addToSlot = Map.empty,
       slotNum = 0,
       txStatus = TransactionStatus.Unprocessed,
       chargedFee = 0L,

--- a/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
@@ -30,20 +30,9 @@ class CompositeStateReader(inner: StateReader, blockDiff: BlockDiff) extends Sta
 
   override def height: Int = inner.height + blockDiff.heightDiff
 
-  override def slotAddress(id: Int): Option[String] =
-    txDiff.slotids.get(id) match {
-      case None => inner.slotAddress(id).orElse(None)
-      case Some(None) => None
-      case Some(add) => add
-    }
+  override def slotAddress(id: Int): Option[String] = txDiff.slotids.getOrElse(id, inner.slotAddress(id))
 
-  override def addressSlot(add: String): Option[Int] = {
-    txDiff.addToSlot.get(add) match {
-      case None => inner.addressSlot(add)
-      case Some(None) => None
-      case Some(id) => id
-    }
-  }
+  override def addressSlot(add: String): Option[Int] = txDiff.addToSlot.getOrElse(add, inner.addressSlot(add))
 
   override def effectiveSlotAddressSize: Int = inner.effectiveSlotAddressSize + txDiff.slotNum
 

--- a/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
@@ -33,15 +33,13 @@ class CompositeStateReader(inner: StateReader, blockDiff: BlockDiff) extends Sta
   override def slotAddress(id: Int): Option[String] =
     txDiff.slotids.get(id) match {
       case None => inner.slotAddress(id).orElse(None)
-      case add if add.get == "" => None
-      case add => add
+      case add => add.get
     }
 
   override def addressSlot(add: String): Option[Int] = {
     txDiff.addToSlot.get(add) match {
       case None => inner.addressSlot(add)
-      case id if id.get == -1 => None
-      case id => id
+      case id => id.get
     }
   }
 

--- a/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
@@ -33,13 +33,15 @@ class CompositeStateReader(inner: StateReader, blockDiff: BlockDiff) extends Sta
   override def slotAddress(id: Int): Option[String] =
     txDiff.slotids.get(id) match {
       case None => inner.slotAddress(id).orElse(None)
-      case add => add.get
+      case Some(None) => None
+      case Some(add) => add
     }
 
   override def addressSlot(add: String): Option[Int] = {
     txDiff.addToSlot.get(add) match {
       case None => inner.addressSlot(add)
-      case id => id.get
+      case Some(None) => None
+      case Some(id) => id
     }
   }
 

--- a/src/main/scala/com/wavesplatform/state2/reader/StateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/StateReader.scala
@@ -30,7 +30,7 @@ trait StateReader extends Synchronized {
 
   def slotAddress(id: Int): Option[String]
 
-  def addressToSlotID(add: String): Option[Int]
+  def addressSlot(add: String): Option[Int]
 
   def effectiveSlotAddressSize: Int
 

--- a/src/main/scala/com/wavesplatform/state2/reader/StateReaderImpl.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/StateReaderImpl.scala
@@ -36,7 +36,7 @@ class StateReaderImpl(p: StateStorage, val synchronizationToken: ReentrantReadWr
 
   override def effectiveSlotAddressSize: Int = read {implicit l=> sp().getEffectiveSlotAddressSize}
 
-  override def addressToSlotID(add: String): Option[Int] = read {implicit l=> sp().addressToSlotID(add)}
+  override def addressSlot(add: String): Option[Int] = read {implicit l=> sp().getAddressSlot(add)}
 
   override def accountTransactionIds(a: Address, limit: Int): Seq[ByteStr] = read { implicit l =>
     val totalRecords = sp().accountTransactionsLengths.getOrDefault(a.bytes, 0)


### PR DESCRIPTION
1.  add `address -> slot` diff in `Diff`
2. add `setAddressSlot` method
3. change lot address related state setting
4. `slotNum` diff correction

case: super-node who contended by others can not contend new slot

reason: original `setSlotAddress` function kept the old `address -> slot id` map

however, it seems a good advantage that node can not re-contend a new slot (except the release case).
need to
1. create a new address
2. collect new lease in
3. wait the new MAB reach the bound

result: keeping this property (by @sunnyking ) and update the document

unit test passed with extra check.
```scala
[info] ScalaTest
[info] Run completed in 43 seconds, 771 milliseconds.
[info] Total number of tests run: 325
[info] Suites: completed 102, aborted 0
[info] Tests: succeeded 325, failed 0, canceled 0, ignored 15, pending 2
[info] All tests passed.
[info] Passed: Total 325, Failed 0, Errors 0, Passed 325, Ignored 15, Pending 2
[success] Total time: 109 s, completed Mar 26, 2019 11:15:57 AM
```