### PR TITLE
fix warning in sbt run

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,10 @@ libraryDependencies ++=
     "io.monix" %% "monix" % "2.3.0"
   )
 
+dependencyOverrides ++= Seq(
+  "com.google.guava" % "guava" % "21.0"
+)
+
 sourceGenerators in Compile += Def.task {
   val versionFile = (sourceManaged in Compile).value / "com" / "wavesplatform" / "Version.scala"
   val versionExtractor = """(\d+)\.(\d+)\.(\d+).*""".r


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add ```dependencyOverrides``` in build.sbt to specify "guava" version. In oder to avoid warning related to "guava" version confilct.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The warning message came out every time running sbt.
```
[warn] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[warn] 	* com.google.guava:guava:21.0 is selected over {19.0, 20.0}
[warn] 	    +- systems.v:vsys:0.1.1                               (depends on 21.0)
[warn] 	    +- io.swagger:swagger-core:1.5.16                     (depends on 20.0)
[warn] 	    +- org.reflections:reflections:0.9.11                 (depends on 20.0)
[warn] 	    +- io.swagger:swagger-jaxrs:1.5.16                    (depends on 20.0)
[warn] 	    +- org.scorexfoundation:scrypto_2.12:1.2.2            (depends on 19.0)
[warn] Run 'evicted' to see detailed eviction warnings
```
This PR is to make the log clean.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- run ```sbt clean test``` locally
- the warning never showed again
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
