### PR TITLE
add token opc without tokenIndex functions

### DIFF
--- a/src/main/scala/vsys/contract/ContractPermitted.scala
+++ b/src/main/scala/vsys/contract/ContractPermitted.scala
@@ -54,16 +54,16 @@ object ContractPermitted {
   object ProtoType {
     val initParaType: Array[Byte] = Array(DataType.Amount.id.toByte, DataType.Amount.id.toByte, DataType.ShortText.id.toByte)
     val supersedeParaType: Array[Byte] = Array(DataType.Account.id.toByte)
-    val issueParaType: Array[Byte] = Array(DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-    val destroyParaType: Array[Byte] = Array(DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-    val splitParaType: Array[Byte] = Array(DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-    val sendParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-    val transferParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.Account.id.toByte, DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-    val depositParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.ContractAccount.id.toByte, DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-    val withdrawParaType: Array[Byte] = Array(DataType.ContractAccount.id.toByte, DataType.Account.id.toByte, DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-    val totalSupplyParaType: Array[Byte] = Array(DataType.Int32.id.toByte)
-    val maxSupplyParaType: Array[Byte] = Array(DataType.Int32.id.toByte)
-    val balanceOfParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.Int32.id.toByte)
+    val issueParaType: Array[Byte] = Array(DataType.Amount.id.toByte)
+    val destroyParaType: Array[Byte] = Array(DataType.Amount.id.toByte)
+    val splitParaType: Array[Byte] = Array(DataType.Amount.id.toByte)
+    val sendParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.Amount.id.toByte)
+    val transferParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.Account.id.toByte, DataType.Amount.id.toByte)
+    val depositParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.ContractAccount.id.toByte, DataType.Amount.id.toByte)
+    val withdrawParaType: Array[Byte] = Array(DataType.ContractAccount.id.toByte, DataType.Account.id.toByte, DataType.Amount.id.toByte)
+    val totalSupplyParaType: Array[Byte] = Array()
+    val maxSupplyParaType: Array[Byte] = Array()
+    val balanceOfParaType: Array[Byte] = Array(DataType.Account.id.toByte)
     val getIssuerParaType: Array[Byte] = Array()
   }
 
@@ -125,74 +125,58 @@ object ContractPermitted {
 
     object issueInput {
       val amountIndex: Byte = 0
-      val tokenIndex: Byte = 1
-      val issuerGetIndex: Byte = 2
+      val issuerGetIndex: Byte = 1
     }
 
     object destroyInput {
       val amountIndex: Byte = 0
-      val tokenIndex: Byte = 1
-      val issuerGetIndex: Byte = 2
+      val issuerGetIndex: Byte = 1
     }
 
     object splitInput {
       val amountIndex: Byte = 0
-      val tokenIndex: Byte = 1
-      val issuerGetIndex: Byte = 2
+      val issuerGetIndex: Byte = 1
     }
 
     object sendInput {
       val receiptIndex: Byte = 0
       val amountIndex: Byte = 1
-      val tokenIndex: Byte = 2
-      val callerLoadIndex: Byte = 3
+      val callerLoadIndex: Byte = 2
     }
 
     object transferInput {
       val senderIndex: Byte = 0
       val receiptIndex: Byte = 1
       val amountIndex: Byte = 2
-      val tokenIndex: Byte = 3
     }
 
     object depositInput {
       val senderIndex: Byte = 0
       val smartIndex: Byte = 1
       val amountIndex: Byte = 2
-      val tokenIndex: Byte = 3
     }
 
     object withdrawInput {
       val smartIndex: Byte = 0
       val receiptIndex: Byte = 1
       val amountIndex: Byte = 2
-      val tokenIndex: Byte = 3
-    }
-
-    object totalSupplyInput {
-      val tokenIndex: Byte = 0
-    }
-
-    object maxSupplyInput {
-      val tokenIndex: Byte = 0
     }
 
     object balanceOfInput {
       val addressIndex: Byte = 0
-      val tokenIndex: Byte = 1
     }
 
   }
 
   object ListOpc {
     val opcLoadSignerIndex: Array[Byte] = Array(3.toByte)
-    val opcLoadCallerIndex: Array[Byte] = Array(3.toByte)
+    val opcLoadCallerIndex: Array[Byte] = Array(2.toByte)
 
     val opcCDBVSetIssuerInitIndex: Array[Byte] = Array(StateVar.issuer, DataStack.initInput.issuerLoadIndex)
     val opcCDBVSetIssuerSupersedeIndex: Array[Byte] = Array(StateVar.issuer, DataStack.supersedeIndex.newIssuerIndex)
     val opcCDBVSetMakerIndex: Array[Byte] = Array(StateVar.maker, DataStack.initInput.issuerLoadIndex)
 
-    val opcCDBVRGetIssuerIndex: Array[Byte] = Array(StateVar.issuer, 2.toByte)
+    val opcCDBVRGetIssuerIndex: Array[Byte] = Array(StateVar.issuer, 1.toByte)
     val opcCDBVRGetMakerIndex: Array[Byte] = Array(StateVar.maker, 1.toByte)
 
     val opcAssertIsCallerOriginIssueIndex: Array[Byte] = Array(DataStack.issueInput.issuerGetIndex)
@@ -204,19 +188,19 @@ object ContractPermitted {
     val opcAssertIsMakerOriginSupersedeIndex: Array[Byte] = Array(DataStack.supersedeIndex.maker)
 
     val opcTDBNewTokenIndex: Array[Byte] = Array(DataStack.initInput.maxIndex, DataStack.initInput.unityIndex, DataStack.initInput.shortTextIndex)
-    val opcTDBSplitIndex: Array[Byte] = Array(DataStack.splitInput.amountIndex, DataStack.splitInput.tokenIndex)
+    val opcTDBSplitIndex: Array[Byte] = Array(DataStack.splitInput.amountIndex)
 
-    val opcTDBRTotalIndex: Array[Byte] = Array(DataStack.totalSupplyInput.tokenIndex, 1.toByte)
-    val opcTDBRMaxIndex: Array[Byte] = Array(DataStack.maxSupplyInput.tokenIndex, 1.toByte)
+    val opcTDBRTotalIndex: Array[Byte] = Array(0.toByte)
+    val opcTDBRMaxIndex: Array[Byte] = Array(0.toByte)
 
-    val opcTDBADepositIssueIndex: Array[Byte] = Array(DataStack.issueInput.issuerGetIndex, DataStack.issueInput.amountIndex, DataStack.issueInput.tokenIndex)
-    val opcTDBAWithdrawDestroyIndex: Array[Byte] = Array(DataStack.destroyInput.issuerGetIndex, DataStack.destroyInput.amountIndex, DataStack.destroyInput.tokenIndex)
-    val opcTDBATransferSendIndex: Array[Byte] = Array(DataStack.sendInput.callerLoadIndex, DataStack.sendInput.receiptIndex, DataStack.sendInput.amountIndex, DataStack.sendInput.tokenIndex)
-    val opcTDBATransferTransferIndex: Array[Byte] = Array(DataStack.transferInput.senderIndex, DataStack.transferInput.receiptIndex, DataStack.transferInput.amountIndex, DataStack.transferInput.tokenIndex)
-    val opcTDBATransferDepositIndex: Array[Byte] = Array(DataStack.depositInput.senderIndex, DataStack.depositInput.smartIndex, DataStack.depositInput.amountIndex, DataStack.depositInput.tokenIndex)
-    val opcTDBATransferWithdrawIndex: Array[Byte] = Array(DataStack.withdrawInput.smartIndex, DataStack.withdrawInput.receiptIndex, DataStack.withdrawInput.amountIndex, DataStack.withdrawInput.tokenIndex)
+    val opcTDBADepositIssueIndex: Array[Byte] = Array(DataStack.issueInput.issuerGetIndex, DataStack.issueInput.amountIndex)
+    val opcTDBAWithdrawDestroyIndex: Array[Byte] = Array(DataStack.destroyInput.issuerGetIndex, DataStack.destroyInput.amountIndex)
+    val opcTDBATransferSendIndex: Array[Byte] = Array(DataStack.sendInput.callerLoadIndex, DataStack.sendInput.receiptIndex, DataStack.sendInput.amountIndex)
+    val opcTDBATransferTransferIndex: Array[Byte] = Array(DataStack.transferInput.senderIndex, DataStack.transferInput.receiptIndex, DataStack.transferInput.amountIndex)
+    val opcTDBATransferDepositIndex: Array[Byte] = Array(DataStack.depositInput.senderIndex, DataStack.depositInput.smartIndex, DataStack.depositInput.amountIndex)
+    val opcTDBATransferWithdrawIndex: Array[Byte] = Array(DataStack.withdrawInput.smartIndex, DataStack.withdrawInput.receiptIndex, DataStack.withdrawInput.amountIndex)
 
-    val opcTDBARBalanceOfIndex: Array[Byte] = Array(DataStack.balanceOfInput.addressIndex, DataStack.balanceOfInput.tokenIndex, 2.toByte)
+    val opcTDBARBalanceOfIndex: Array[Byte] = Array(DataStack.balanceOfInput.addressIndex, 1.toByte)
 
     // init
     val initOpc: List[Array[Byte]] = List(OpcId.opcLoadSigner, OpcId.opcCDBVSet, OpcId.opcCDBVSet, OpcId.opcTDBNewToken)
@@ -250,13 +234,13 @@ object ContractPermitted {
     val withdrawOpcIndex: List[Array[Byte]] = List(opcAssertIsCallerOriginWithdrawIndex, opcTDBATransferWithdrawIndex)
     // totalSupply
     val totalSupplyOpc: List[Array[Byte]] = List(OpcId.opcTDBROpcTotal, OpcId.opcReturnValue)
-    val totalSupplyOpcIndex: List[Array[Byte]] = List(opcTDBRTotalIndex, Array(1.toByte))
+    val totalSupplyOpcIndex: List[Array[Byte]] = List(opcTDBRTotalIndex, Array(0.toByte))
     // maxSupplyOpc
     val maxSupplyOpc: List[Array[Byte]] = List(OpcId.opcTDBROpcMax, OpcId.opcReturnValue)
-    val maxSupplyOpcIndex: List[Array[Byte]] = List(opcTDBRMaxIndex, Array(1.toByte))
+    val maxSupplyOpcIndex: List[Array[Byte]] = List(opcTDBRMaxIndex, Array(0.toByte))
     // balanceOfOpc
     val balanceOfOpc: List[Array[Byte]] = List(OpcId.opcTDBARBalance, OpcId.opcReturnValue)
-    val balanceOfOpcIndex: List[Array[Byte]] = List(opcTDBARBalanceOfIndex, Array(2.toByte))
+    val balanceOfOpcIndex: List[Array[Byte]] = List(opcTDBARBalanceOfIndex, Array(1.toByte))
     // getIssuerOpc
     val getIssuerOpc: List[Array[Byte]] = List(OpcId.opcCDBVRGet, OpcId.opcReturnValue)
     val getIssuerOpcIndex: List[Array[Byte]] = List(Array(StateVar.issuer, 0.toByte), Array(0.toByte))
@@ -324,16 +308,16 @@ object ContractPermitted {
   object ParaName {
     val initPara: Seq[String] = Seq("max", "unity", "tokenDescription", "signer")
     val supersedePara: Seq[String] = Seq("newIssuer", "maker")
-    val issuePara: Seq[String] = Seq("amount", "tokenIndex", "issuer")
-    val destroyPara: Seq[String] = Seq("amount", "tokenIndex", "issuer")
-    val splitPara: Seq[String] = Seq("newUnity", "tokenIndex", "issuer")
-    val sendPara: Seq[String] = Seq("receipt", "amount", "tokenIndex", "caller")
-    val transferPara: Seq[String]= Seq("sender", "receipt", "amount", "tokenIndex")
-    val depositPara: Seq[String] = Seq("sender", "smart", "amount", "tokenIndex")
-    val withdrawPara: Seq[String]= Seq("smart", "receipt", "amount", "tokenIndex")
-    val totalSupplyPara: Seq[String] = Seq("tokenIndex", "total")
-    val maxSupplyPara: Seq[String] = Seq("tokenIndex", "max")
-    val balanceOfPara: Seq[String] = Seq("address", "tokenIndex", "balance")
+    val issuePara: Seq[String] = Seq("amount", "issuer")
+    val destroyPara: Seq[String] = Seq("amount", "issuer")
+    val splitPara: Seq[String] = Seq("newUnity", "issuer")
+    val sendPara: Seq[String] = Seq("receipt", "amount", "caller")
+    val transferPara: Seq[String]= Seq("sender", "receipt", "amount")
+    val depositPara: Seq[String] = Seq("sender", "smart", "amount")
+    val withdrawPara: Seq[String]= Seq("smart", "receipt", "amount")
+    val totalSupplyPara: Seq[String] = Seq("total")
+    val maxSupplyPara: Seq[String] = Seq("max")
+    val balanceOfPara: Seq[String] = Seq("address", "balance")
     val getIssuerPara: Seq[String] = Seq("issuer")
   }
 

--- a/src/main/scala/vsys/state/opcdiffs/TDBAROpcDiff.scala
+++ b/src/main/scala/vsys/state/opcdiffs/TDBAROpcDiff.scala
@@ -33,12 +33,21 @@ object TDBAROpcDiff {
     }
   }
 
+  def balanceWithoutTokenIndex(context: ExecutionContext)(address: DataEntry,
+                                         dataStack: Seq[DataEntry], pointer: Byte): Either[ValidationError, Seq[DataEntry]] = {
+
+    val tokenIndex = DataEntry(Ints.toByteArray(0), DataType.Int32)
+    balance(context)(address, tokenIndex, dataStack, pointer)
+  }
+
   object TDBARType extends Enumeration {
     val BalanceTBDAR= Value(1)
   }
 
   def parseBytes(context: ExecutionContext)
                 (bytes: Array[Byte], data: Seq[DataEntry]): Either[ValidationError, Seq[DataEntry]] = bytes.head match {
+    case opcType: Byte if opcType == TDBARType.BalanceTBDAR.id && checkInput(bytes.slice(0, bytes.length - 1), 2, context.stateVar.length, data.length, 1) =>
+      balanceWithoutTokenIndex(context)(data(bytes(1)), data, bytes(2))
     case opcType: Byte if opcType == TDBARType.BalanceTBDAR.id && checkInput(bytes.slice(0, bytes.length - 1), 3, context.stateVar.length, data.length, 1) =>
       balance(context)(data(bytes(1)), data(bytes(2)), data, bytes(3))
     case _ => Left(GenericError("Wrong TDBAR opcode"))

--- a/src/main/scala/vsys/state/opcdiffs/TDBOpcDiff.scala
+++ b/src/main/scala/vsys/state/opcdiffs/TDBOpcDiff.scala
@@ -59,6 +59,13 @@ object TDBOpcDiff {
     }
   }
 
+  def splitWithoutTokenIndex(context: ExecutionContext)
+           (newUnity: DataEntry): Either[ValidationError, OpcDiff] = {
+
+    val tokenIndex = DataEntry(Ints.toByteArray(0), DataType.Int32)
+    split(context)(newUnity, tokenIndex)
+  }
+
   object TDBType extends Enumeration {
     val NewTokenTDB = Value(1)
     val SplitTDB = Value(2)
@@ -68,6 +75,8 @@ object TDBOpcDiff {
                 (bytes: Array[Byte], data: Seq[DataEntry]): Either[ValidationError, OpcDiff] = bytes.head match {
     case opcType: Byte if opcType == TDBType.NewTokenTDB.id && checkInput(bytes,4, data.length) =>
       newToken(context)(data(bytes(1)), data(bytes(2)), data(bytes(3)))
+    case opcType: Byte if opcType == TDBType.SplitTDB.id && checkInput(bytes,2, data.length) =>
+      splitWithoutTokenIndex(context)(data(bytes(1)))
     case opcType: Byte if opcType == TDBType.SplitTDB.id && checkInput(bytes,3, data.length) =>
       split(context)(data(bytes(1)), data(bytes(2)))
     case _ => Left(GenericError("Wrong TDB opcode"))

--- a/src/main/scala/vsys/state/opcdiffs/TDBROpcDiff.scala
+++ b/src/main/scala/vsys/state/opcdiffs/TDBROpcDiff.scala
@@ -155,7 +155,7 @@ object TDBROpcDiff {
   }
 
   private def checkInput(bytes: Array[Byte], bLength: Int, dataLength: Int): Boolean = {
-    bytes.length == bLength && bytes.tail.max < dataLength && bytes.tail.min >= 0
+    bytes.length == bLength && (bytes.length == 1 || (bytes.tail.max < dataLength && bytes.tail.min >= 0))
   }
 
 }

--- a/src/main/scala/vsys/state/opcdiffs/TDBROpcDiff.scala
+++ b/src/main/scala/vsys/state/opcdiffs/TDBROpcDiff.scala
@@ -34,6 +34,12 @@ object TDBROpcDiff {
     }
   }
 
+  def maxWithoutTokenIndex(context: ExecutionContext)(dataStack: Seq[DataEntry], pointer: Byte): Either[ValidationError, Seq[DataEntry]] = {
+
+    val tokenIndex = DataEntry(Ints.toByteArray(0), DataType.Int32)
+    max(context)(tokenIndex, dataStack, pointer)
+  }
+
   // in current version only total store in tokenAccountBalance DB
   def total(context: ExecutionContext)(tokenIndex: DataEntry,
                                        dataStack: Seq[DataEntry], pointer: Byte): Either[ValidationError, Seq[DataEntry]] = {
@@ -54,6 +60,12 @@ object TDBROpcDiff {
         Right(dataStack.patch(pointer, Seq(DataEntry(Longs.toByteArray(t), DataType.Amount)), 1))
       }
     }
+  }
+
+  def totalWithoutTokenIndex(context: ExecutionContext)(dataStack: Seq[DataEntry], pointer: Byte): Either[ValidationError, Seq[DataEntry]] = {
+
+    val tokenIndex = DataEntry(Ints.toByteArray(0), DataType.Int32)
+    total(context)(tokenIndex, dataStack, pointer)
   }
 
   def unity(context: ExecutionContext)(tokenIndex: DataEntry,
@@ -79,6 +91,12 @@ object TDBROpcDiff {
     }
   }
 
+  def unityWithoutTokenIndex(context: ExecutionContext)(dataStack: Seq[DataEntry], pointer: Byte): Either[ValidationError, Seq[DataEntry]] = {
+
+    val tokenIndex = DataEntry(Ints.toByteArray(0), DataType.Int32)
+    unity(context)(tokenIndex, dataStack, pointer)
+  }
+
   def desc(context: ExecutionContext)(tokenIndex: DataEntry,
                                       dataStack: Seq[DataEntry], pointer: Byte): Either[ValidationError, Seq[DataEntry]] = {
 
@@ -102,6 +120,12 @@ object TDBROpcDiff {
     }
   }
 
+  def descWithoutTokenIndex(context: ExecutionContext)(dataStack: Seq[DataEntry], pointer: Byte): Either[ValidationError, Seq[DataEntry]] = {
+
+    val tokenIndex = DataEntry(Ints.toByteArray(0), DataType.Int32)
+    desc(context)(tokenIndex, dataStack, pointer)
+  }
+
   object TDBRType extends Enumeration {
     val MaxTDBR = Value(1)
     val TotalTDBR = Value(2)
@@ -111,12 +135,20 @@ object TDBROpcDiff {
 
   def parseBytes(context: ExecutionContext)
                 (bytes: Array[Byte], data: Seq[DataEntry]): Either[ValidationError, Seq[DataEntry]] = bytes.head match {
+    case opcType: Byte if opcType == TDBRType.MaxTDBR.id && checkInput(bytes.slice(0, bytes.length - 1),1, data.length) =>
+      maxWithoutTokenIndex(context)(data, bytes(1))
     case opcType: Byte if opcType == TDBRType.MaxTDBR.id && checkInput(bytes.slice(0, bytes.length - 1),2, data.length) =>
       max(context)(data(bytes(1)), data, bytes(2))
+    case opcType: Byte if opcType == TDBRType.TotalTDBR.id && checkInput(bytes.slice(0, bytes.length - 1),1, data.length) =>
+      totalWithoutTokenIndex(context)(data, bytes(1))
     case opcType: Byte if opcType == TDBRType.TotalTDBR.id && checkInput(bytes.slice(0, bytes.length - 1),2, data.length) =>
       total(context)(data(bytes(1)), data, bytes(2))
+    case opcType: Byte if opcType == TDBRType.UnityTDBR.id && checkInput(bytes.slice(0, bytes.length - 1),1, data.length) =>
+      unityWithoutTokenIndex(context)(data, bytes(1))
     case opcType: Byte if opcType == TDBRType.UnityTDBR.id && checkInput(bytes.slice(0, bytes.length - 1),2, data.length) =>
       unity(context)(data(bytes(1)), data, bytes(2))
+    case opcType: Byte if opcType == TDBRType.DescTDBR.id && checkInput(bytes.slice(0, bytes.length - 1),1, data.length) =>
+      descWithoutTokenIndex(context)(data, bytes(1))
     case opcType: Byte if opcType == TDBRType.DescTDBR.id && checkInput(bytes.slice(0, bytes.length - 1),2, data.length) =>
       desc(context)(data(bytes(1)), data, bytes(2))
     case _ => Left(GenericError("Wrong TDBR opcode"))

--- a/src/test/scala/tools/ContractTranslator.scala
+++ b/src/test/scala/tools/ContractTranslator.scala
@@ -72,7 +72,7 @@ object ContractTranslator extends App {
           // TODO
           // need a more complex ftTypes check
           // print function or trigger type
-          val ftType = if (tp == 0) "OnInit Trigger" else "Public Function"
+          val ftType = if (tp == 0) "onInit trigger" else "public function"
           print(ftType + " ")
 
           // print function or trigger name
@@ -222,59 +222,59 @@ object ContractTranslator extends App {
           case opcType: Byte if opcType == AssertType.LtInt64Assert.id => "opc_assert_ltInt64"
           case opcType: Byte if opcType == AssertType.GtZeroAssert.id => "opc_assert_gt0"
           case opcType: Byte if opcType == AssertType.EqAssert.id => "opc_assert_eq"
-          case opcType: Byte if opcType == AssertType.IsCallerOriginAssert.id => "opc_assert_caller(" + nameList(data(2)) + ")"
-          case opcType: Byte if opcType == AssertType.IsSignerOriginAssert.id => "opc_assert_singer(" + nameList(data(2)) + ")"
+          case opcType: Byte if opcType == AssertType.IsCallerOriginAssert.id => "operation.check.assertCaller(" + nameList(data(2)) + ")"
+          case opcType: Byte if opcType == AssertType.IsSignerOriginAssert.id => "operation.check.assertSigner(" + nameList(data(2)) + ")"
           case _ => "--- invalid opc code ---"
         }
 
       case opcType: Byte if opcType == OpcType.LoadOpc.id =>
         y match {
-          case opcType: Byte if opcType == LoadType.SignerLoad.id => nameList(data(2)) + " = opc_load_env_signer()"
-          case opcType: Byte if opcType == LoadType.CallerLoad.id => nameList(data(2)) + " = opc_load_env_caller()"
+          case opcType: Byte if opcType == LoadType.SignerLoad.id => nameList(data(2)) + " = operation.env.getSigner()"
+          case opcType: Byte if opcType == LoadType.CallerLoad.id => nameList(data(2)) + " = operation.env.getCaller()"
           case _ => "--- invalid opc code ---"
         }
 
       case opcType: Byte if opcType == OpcType.CDBVOpc.id =>
         y match {
-          case opcType: Byte if opcType == CDBVType.SetCDBV.id => "cdb." + stateNameList(data(2)) + " = opc_cdbv_set(" + nameList(data(3)) + ")"
+          case opcType: Byte if opcType == CDBVType.SetCDBV.id => "operation.db.setVariable(" + "db." + stateNameList(data(2)) + ", " + nameList(data(3)) + ")"
           case _ => "--- invalid opc code ---"
         }
 
       case opcType: Byte if opcType == OpcType.CDBVROpc.id =>
         y match {
-          case opcType: Byte if opcType == CDBVRType.GetCDBVR.id => nameList(data(3)) + " = opc_cdbvr_get(cdb." + stateNameList(data(2)) + ")"
+          case opcType: Byte if opcType == CDBVRType.GetCDBVR.id => nameList(data(3)) + " = operation.db.getVariable(db." + stateNameList(data(2)) + ")"
           case _ => "--- invalid opc code ---"
         }
 
       case opcType: Byte if opcType == OpcType.TDBOpc.id =>
         y match {
-          case opcType: Byte if opcType == TDBType.NewTokenTDB.id => "opc_tdb_new(" + nameList(data(2)) + ", " + nameList(data(3)) + ", " + nameList(data(4)) + ")"
-          case opcType: Byte if opcType == TDBType.SplitTDB.id => "opc_tdb_split(" + nameList(data(2)) + ", " + nameList(data(3)) + ")"
+          case opcType: Byte if opcType == TDBType.NewTokenTDB.id => "operation.token.new(" + nameList(data(2)) + ", " + nameList(data(3)) + ", " + nameList(data(4)) + ")"
+          case opcType: Byte if opcType == TDBType.SplitTDB.id => "operation.token.split(" + nameList(data(2)) + ")"
           case _ => "--- invalid opc code ---"
         }
 
       case opcType: Byte if opcType == OpcType.TDBROpc.id =>
         y match {
-          case opcType: Byte if opcType == TDBRType.MaxTDBR.id => nameList(data(3)) + " = opc_tdbr_max(" + nameList(data(2)) + ")"
-          case opcType: Byte if opcType == TDBRType.TotalTDBR.id => nameList(data(3)) + " = opc_tdbr_total(" + nameList(data(2)) + ")"
+          case opcType: Byte if opcType == TDBRType.MaxTDBR.id => nameList(data(2)) + " = operation.token.getMaxSupply(" + ")"
+          case opcType: Byte if opcType == TDBRType.TotalTDBR.id => nameList(data(2)) + " = operation.token.getTotalSupply(" + ")"
           case _ => "--- invalid opc code ---"
         }
 
       case opcType: Byte if opcType == OpcType.TDBAOpc.id =>
         y match {
-          case opcType: Byte if opcType == TDBAType.DepositTDBA.id => "opc_tdba_deposit(" + nameList(data(2)) + ", " + nameList(data(3)) + ", " + nameList(data(4)) + ")"
-          case opcType: Byte if opcType == TDBAType.WithdrawTDBA.id => "opc_tdba_withdraw(" + nameList(data(2)) + ", " + nameList(data(3)) + ", " + nameList(data(4)) + ")"
-          case opcType: Byte if opcType == TDBAType.TransferTDBA.id => "opc_tdba_transfer(" + nameList(data(2)) + ", " + nameList(data(3)) + ", " + nameList(data(4)) + ", " + nameList(data(5)) + ")"
+          case opcType: Byte if opcType == TDBAType.DepositTDBA.id => "operation.token.deposit(" + nameList(data(2)) + ", " + nameList(data(3)) + ")"
+          case opcType: Byte if opcType == TDBAType.WithdrawTDBA.id => "operation.token.withdraw(" + nameList(data(2)) + ", " + nameList(data(3)) + ")"
+          case opcType: Byte if opcType == TDBAType.TransferTDBA.id => "operation.token.transfer(" + nameList(data(2)) + ", " + nameList(data(3)) + ", " + nameList(data(4)) + ")"
           case _ => "--- invalid opc code ---"
         }
 
       case opcType: Byte if opcType == OpcType.TDBAROpc.id =>
         y match {
-          case opcType: Byte if opcType == TDBARType.BalanceTBDAR.id => nameList(data(4)) + " = opc_tdbar_balance(" + nameList(data(2)) + ", " + nameList(data(3)) + ")"
+          case opcType: Byte if opcType == TDBARType.BalanceTBDAR.id => nameList(data(3)) + " = operation.token.getBalance(" + nameList(data(2)) + ")"
           case _ => "--- invalid opc code ---"
         }
 
-      case opcType: Byte if opcType == OpcType.ReturnOpc.id => "opc_value_return " + nameList(data(2))
+      case opcType: Byte if opcType == OpcType.ReturnOpc.id => "operation.control.return(" + nameList(data(2)) + ")"
 
       case _ => "--- invalid opc code ---"
 

--- a/src/test/scala/vsys/contract/DataStack.scala
+++ b/src/test/scala/vsys/contract/DataStack.scala
@@ -21,21 +21,38 @@ trait DataStack {
     index <- Gen.const(DataEntry(Ints.toByteArray(tokenIndex), DataType.Int32))
   } yield Seq(unit, index)
 
+  def splitDataStackGen(newUnity: Long): Gen[Seq[DataEntry]] = for {
+    unit <- Gen.const(DataEntry(Longs.toByteArray(newUnity), DataType.Amount))
+  } yield Seq(unit)
+
   def destroyDataStackGen(amount: Long, tokenIndex: Int): Gen[Seq[DataEntry]] = for {
     am <- Gen.const(DataEntry(Longs.toByteArray(amount), DataType.Amount))
     index <- Gen.const(DataEntry(Ints.toByteArray(tokenIndex), DataType.Int32))
   } yield Seq(am, index)
+
+  def destroyDataStackGen(amount: Long): Gen[Seq[DataEntry]] = for {
+    am <- Gen.const(DataEntry(Longs.toByteArray(amount), DataType.Amount))
+  } yield Seq(am)
 
   def issueDataStackGen(amount: Long, tokenIndex: Int): Gen[Seq[DataEntry]] = for {
     max <- Gen.const(DataEntry(Longs.toByteArray(amount), DataType.Amount))
     index <- Gen.const(DataEntry(Ints.toByteArray(tokenIndex), DataType.Int32))
   } yield Seq(max, index)
 
+  def issueDataStackGen(amount: Long): Gen[Seq[DataEntry]] = for {
+    max <- Gen.const(DataEntry(Longs.toByteArray(amount), DataType.Amount))
+  } yield Seq(max)
+
   def sendDataStackGen(recipient: Address, amount: Long, tokenIndex: Int): Gen[Seq[DataEntry]] = for {
     reci <- Gen.const(DataEntry(recipient.bytes.arr, DataType.Address))
     am <- Gen.const(DataEntry(Longs.toByteArray(amount), DataType.Amount))
     index <- Gen.const(DataEntry(Ints.toByteArray(tokenIndex), DataType.Int32))
   } yield Seq(reci, am, index)
+
+  def sendDataStackGen(recipient: Address, amount: Long): Gen[Seq[DataEntry]] = for {
+    reci <- Gen.const(DataEntry(recipient.bytes.arr, DataType.Address))
+    am <- Gen.const(DataEntry(Longs.toByteArray(amount), DataType.Amount))
+  } yield Seq(reci, am)
 
   def transferDataStackGen(sender: Address, recipient: Address, amount: Long, tokenIndex: Int): Gen[Seq[DataEntry]] = for {
     se <- Gen.const(DataEntry(sender.bytes.arr, DataType.Address))
@@ -44,6 +61,12 @@ trait DataStack {
     index <- Gen.const(DataEntry(Ints.toByteArray(tokenIndex), DataType.Int32))
   } yield Seq(se, reci, am, index)
 
+  def transferDataStackGen(sender: Address, recipient: Address, amount: Long): Gen[Seq[DataEntry]] = for {
+    se <- Gen.const(DataEntry(sender.bytes.arr, DataType.Address))
+    reci <- Gen.const(DataEntry(recipient.bytes.arr, DataType.Address))
+    am <- Gen.const(DataEntry(Longs.toByteArray(amount), DataType.Amount))
+  } yield Seq(se, reci, am)
+
   def depositDataStackGen(sender: Address, smartContract: Address, amount: Long, tokenIndex: Int): Gen[Seq[DataEntry]] = for {
     se <- Gen.const(DataEntry(sender.bytes.arr, DataType.Address))
     sc <- Gen.const(DataEntry(smartContract.bytes.arr, DataType.Address))
@@ -51,12 +74,24 @@ trait DataStack {
     index <- Gen.const(DataEntry(Ints.toByteArray(tokenIndex), DataType.Int32))
   } yield Seq(se, sc, am, index)
 
+  def depositDataStackGen(sender: Address, smartContract: Address, amount: Long): Gen[Seq[DataEntry]] = for {
+    se <- Gen.const(DataEntry(sender.bytes.arr, DataType.Address))
+    sc <- Gen.const(DataEntry(smartContract.bytes.arr, DataType.Address))
+    am <- Gen.const(DataEntry(Longs.toByteArray(amount), DataType.Amount))
+  } yield Seq(se, sc, am)
+
   def withdrawDataStackGen(smartContract: Address, recipient: Address, amount: Long, tokenIndex: Int): Gen[Seq[DataEntry]] = for {
     sc <- Gen.const(DataEntry(smartContract.bytes.arr, DataType.Address))
     reci <- Gen.const(DataEntry(recipient.bytes.arr, DataType.Address))
     am <- Gen.const(DataEntry(Longs.toByteArray(amount), DataType.Amount))
     index <- Gen.const(DataEntry(Ints.toByteArray(tokenIndex), DataType.Int32))
   } yield Seq(sc, reci, am, index)
+
+  def withdrawDataStackGen(smartContract: Address, recipient: Address, amount: Long): Gen[Seq[DataEntry]] = for {
+    sc <- Gen.const(DataEntry(smartContract.bytes.arr, DataType.Address))
+    reci <- Gen.const(DataEntry(recipient.bytes.arr, DataType.Address))
+    am <- Gen.const(DataEntry(Longs.toByteArray(amount), DataType.Amount))
+  } yield Seq(sc, reci, am)
 
   def totalSupplyDataStackGen(tokenIndex: Int): Gen[Seq[DataEntry]] = for {
     index <- Gen.const(DataEntry(Ints.toByteArray(tokenIndex), DataType.Int32))
@@ -70,9 +105,17 @@ trait DataStack {
     acc <- Gen.const(DataEntry(account.bytes.arr, DataType.Address))
     index <- Gen.const(DataEntry(Ints.toByteArray(tokenIndex), DataType.Int32))
   } yield Seq(acc, index)
+
+  def balanceOfDataStackGen(account: Address): Gen[Seq[DataEntry]] = for {
+    acc <- Gen.const(DataEntry(account.bytes.arr, DataType.Address))
+  } yield Seq(acc)
+
+  def emptyDataStackGen(): Gen[Seq[DataEntry]] = Seq()
 }
 
 object DataStack {
+
+  // case for non tokenIndex case
   object initInput {
     val maxIndex: Byte = 0
     val unityIndex: Byte = 1
@@ -87,60 +130,47 @@ object DataStack {
 
   object splitInput {
     val newUnityIndex: Byte = 0
-    val tokenIndex: Byte = 1
-    val issuerGetIndex: Byte = 2
+    val issuerGetIndex: Byte = 1
   }
 
   object destroyInput {
     val destroyAmountIndex: Byte = 0
-    val tokenIndex: Byte = 1
-    val issuerGetIndex: Byte = 2
+    val issuerGetIndex: Byte = 1
   }
 
   object issueInput {
     val amountIndex: Byte = 0
-    val tokenIndex: Byte = 1
-    val issuerGetIndex: Byte = 2
+    val issuerGetIndex: Byte = 1
   }
 
   object sendInput {
     val recipientIndex: Byte = 0
     val amountIndex: Byte = 1
-    val tokenIndex: Byte = 2
-    val senderIndex: Byte = 3
+    val senderIndex: Byte = 2
   }
 
   object transferInput {
     val senderIndex: Byte = 0
     val recipientIndex: Byte = 1
     val amountIndex: Byte = 2
-    val tokenIndex: Byte = 3
   }
 
   object depositInput {
     val senderIndex: Byte = 0
     val smartContractIndex: Byte = 1
     val amountIndex: Byte = 2
-    val tokenIndex: Byte = 3
   }
 
   object withdrawInput {
     val smartContractIndex: Byte = 0
     val recipientIndex: Byte = 1
     val amountIndex: Byte = 2
-    val tokenIndex: Byte = 3
-  }
-
-  object totalSupplyInput {
-    val tokenIndex: Byte = 0
-  }
-
-  object maxSupplyInput {
-    val tokenIndex: Byte = 0
   }
 
   object balanceOfInput {
     val accountIndex: Byte = 0
-    val tokenIndex: Byte = 1
   }
+
+  // TODO
+  // with tokenIndex cases
 }

--- a/src/test/scala/vsys/contract/OpcFunction.scala
+++ b/src/test/scala/vsys/contract/OpcFunction.scala
@@ -202,18 +202,18 @@ object ProtoType {
   val initParaTypeWrong: Array[Byte] = Array(DataType.Amount.id.toByte, DataType.Amount.id.toByte)
   val initParaType: Array[Byte] = Array(DataType.Amount.id.toByte, DataType.Amount.id.toByte, DataType.ShortText.id.toByte)
   val supersedeParaType: Array[Byte] = Array(DataType.Account.id.toByte)
-  val issueParaType: Array[Byte] = Array(DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-  val destroyParaType: Array[Byte] = Array(DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-  val splitParaType: Array[Byte] = Array(DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-  val sendParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-  val transferParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.Account.id.toByte, DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-  val depositParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.ContractAccount.id.toByte, DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-  // val depositParaType: List[Byte] = List(DataType.Address.id.toByte, DataType.Address.id.toByte, DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-  val withdrawParaType: Array[Byte] = Array(DataType.ContractAccount.id.toByte, DataType.Account.id.toByte, DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-  //val withdrawParaType: List[Byte] = List(DataType.Address.id.toByte, DataType.Address.id.toByte, DataType.Amount.id.toByte, DataType.Int32.id.toByte)
-  val totalSupplyParaType: Array[Byte] = Array(DataType.Int32.id.toByte)
-  val maxSupplyParaType: Array[Byte] = Array(DataType.Int32.id.toByte)
-  val balanceOfParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.Int32.id.toByte)
+  val issueParaType: Array[Byte] = Array(DataType.Amount.id.toByte)
+  val destroyParaType: Array[Byte] = Array(DataType.Amount.id.toByte)
+  val splitParaType: Array[Byte] = Array(DataType.Amount.id.toByte)
+  val sendParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.Amount.id.toByte)
+  val transferParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.Account.id.toByte, DataType.Amount.id.toByte)
+  val depositParaType: Array[Byte] = Array(DataType.Account.id.toByte, DataType.ContractAccount.id.toByte, DataType.Amount.id.toByte)
+  // val depositParaType: List[Byte] = List(DataType.Address.id.toByte, DataType.Address.id.toByte, DataType.Amount.id.toByte)
+  val withdrawParaType: Array[Byte] = Array(DataType.ContractAccount.id.toByte, DataType.Account.id.toByte, DataType.Amount.id.toByte)
+  //val withdrawParaType: List[Byte] = List(DataType.Address.id.toByte, DataType.Address.id.toByte, DataType.Amount.id.toByte)
+  val totalSupplyParaType: Array[Byte] = Array.empty
+  val maxSupplyParaType: Array[Byte] = Array.empty
+  val balanceOfParaType: Array[Byte] = Array(DataType.Account.id.toByte)
   val getIssuerParaType: Array[Byte] = Array.empty
 }
 
@@ -249,7 +249,7 @@ trait ListOpc extends ByteArrayGen {
 
 object ListOpc {
   val opcLoadSignerIndex: Array[Byte] = Array(3.toByte)
-  val opcLoadCallerIndex: Array[Byte] = Array(3.toByte)
+  val opcLoadCallerIndex: Array[Byte] = Array(2.toByte)
 
   val initOpcCDBVSetSignerIndex: Array[Byte] = Array(StateVar.issuer, DataStack.initInput.issuerLoadIndex)
   val initOpcCDBVSetMakerIndex: Array[Byte] = Array(StateVar.maker, DataStack.initInput.issuerLoadIndex)
@@ -265,59 +265,58 @@ object ListOpc {
   val supersedeOpcIndex: List[Array[Byte]] = List(supersedeOpcCDBVRGetIndex, superAssertIsSignerOriginIndex, supersedeOpcCDBVSetIndex)
 
 
-  val issueOpcCDBVRGetIndex: Array[Byte] = Array(StateVar.issuer, 2.toByte)
+  val issueOpcCDBVRGetIndex: Array[Byte] = Array(StateVar.issuer, 1.toByte)
   val issueOpcAssertIsCallerOriginIndex: Array[Byte] = Array(DataStack.issueInput.issuerGetIndex)
-  val issueOpcTDBADepositIndex: Array[Byte] = Array(DataStack.issueInput.issuerGetIndex, DataStack.issueInput.amountIndex, DataStack.issueInput.tokenIndex)
+  val issueOpcTDBADepositIndex: Array[Byte] = Array(DataStack.issueInput.issuerGetIndex, DataStack.issueInput.amountIndex)
   val issueOpc: List[Array[Byte]] = List(OpcId.opcCDBVRGet, OpcId.opcAssertIsCallerOrigin, OpcId.opcTDBADeposit)
   val issueOpcIndex: List[Array[Byte]] = List(issueOpcCDBVRGetIndex, issueOpcAssertIsCallerOriginIndex, issueOpcTDBADepositIndex)
 
-  val destroyOpcCDBVRGetIndex: Array[Byte] = Array(StateVar.issuer, 2.toByte)
+  val destroyOpcCDBVRGetIndex: Array[Byte] = Array(StateVar.issuer, 1.toByte)
   val destroyOpcAssertIsCallerOriginIndex: Array[Byte] = Array(DataStack.destroyInput.issuerGetIndex)
-  val destroyOpcTDBAWithdrawIndex: Array[Byte] = Array(DataStack.destroyInput.issuerGetIndex, DataStack.destroyInput.destroyAmountIndex,
-    DataStack.destroyInput.tokenIndex)
+  val destroyOpcTDBAWithdrawIndex: Array[Byte] = Array(DataStack.destroyInput.issuerGetIndex, DataStack.destroyInput.destroyAmountIndex)
   val destroyOpc: List[Array[Byte]] = List(OpcId.opcCDBVRGet, OpcId.opcAssertIsCallerOrigin, OpcId.opcTDBAWithdraw)
   val destroyOpcIndex: List[Array[Byte]] = List(destroyOpcCDBVRGetIndex, destroyOpcAssertIsCallerOriginIndex, destroyOpcTDBAWithdrawIndex)
 
-  val splitOpcCDBVRGetIndex: Array[Byte] = Array(StateVar.issuer, 2.toByte)
+  val splitOpcCDBVRGetIndex: Array[Byte] = Array(StateVar.issuer, 1.toByte)
   val splitOpcAssertIsCallerOriginIndex: Array[Byte] = Array(DataStack.splitInput.issuerGetIndex)
-  val splitOpcTDBSplitIndex: Array[Byte] = Array(DataStack.splitInput.newUnityIndex, DataStack.splitInput.tokenIndex)
+  val splitOpcTDBSplitIndex: Array[Byte] = Array(DataStack.splitInput.newUnityIndex)
   val splitOpc: List[Array[Byte]] = List(OpcId.opcCDBVRGet, OpcId.opcAssertIsCallerOrigin, OpcId.opcTDBSplit)
   val splitOpcIndex: List[Array[Byte]] = List(splitOpcCDBVRGetIndex, splitOpcAssertIsCallerOriginIndex, splitOpcTDBSplitIndex)
 
   val sendOpcTDBATransferIndex: Array[Byte] = Array(DataStack.sendInput.senderIndex,
-    DataStack.sendInput.recipientIndex, DataStack.sendInput.amountIndex, DataStack.sendInput.tokenIndex)
+    DataStack.sendInput.recipientIndex, DataStack.sendInput.amountIndex)
   val sendOpc: List[Array[Byte]] = List(OpcId.opcLoadCaller, OpcId.opcTDBATransfer)
   val sendOpcIndex: List[Array[Byte]] = List(opcLoadCallerIndex, sendOpcTDBATransferIndex)
 
   val transferOpcAssertIsCallerOriginIndex: Array[Byte] = Array(DataStack.transferInput.senderIndex)
   val transferOpcTDBATransferIndex: Array[Byte] = Array(DataStack.transferInput.senderIndex, DataStack.transferInput.recipientIndex,
-    DataStack.transferInput.amountIndex, DataStack.transferInput.tokenIndex)
+    DataStack.transferInput.amountIndex)
   val transferOpc: List[Array[Byte]] = List(OpcId.opcAssertIsCallerOrigin, OpcId.opcTDBATransfer)
   val transferOpcIndex: List[Array[Byte]] = List(transferOpcAssertIsCallerOriginIndex, transferOpcTDBATransferIndex)
 
   val depositOpcAssertIsCallerOriginIndex: Array[Byte] = Array(DataStack.depositInput.senderIndex)
   val depositOpcTDBATransferIndex: Array[Byte] = Array(DataStack.depositInput.senderIndex, DataStack.depositInput.smartContractIndex,
-    DataStack.depositInput.amountIndex, DataStack.depositInput.tokenIndex)
+    DataStack.depositInput.amountIndex)
   val depositOpc: List[Array[Byte]] = List(OpcId.opcAssertIsCallerOrigin, OpcId.opcTDBATransfer)
   val depositOpcIndex: List[Array[Byte]] = List(depositOpcAssertIsCallerOriginIndex, depositOpcTDBATransferIndex)
 
   val withdrawOpcAssertIsCallerOriginIndex: Array[Byte] = Array(DataStack.withdrawInput.recipientIndex)
   val withdrawOpcTDBATransferIndex: Array[Byte] = Array(DataStack.withdrawInput.smartContractIndex, DataStack.withdrawInput.recipientIndex,
-    DataStack.withdrawInput.amountIndex, DataStack.withdrawInput.tokenIndex)
+    DataStack.withdrawInput.amountIndex)
   val withdrawOpc: List[Array[Byte]] = List(OpcId.opcAssertIsCallerOrigin, OpcId.opcTDBATransfer)
   val withdrawOpcIndex: List[Array[Byte]] = List(withdrawOpcAssertIsCallerOriginIndex, withdrawOpcTDBATransferIndex)
 
-  val totalSupplyOpcTDBRTotalIndex: Array[Byte] = Array(DataStack.totalSupplyInput.tokenIndex, 1.toByte)
+  val totalSupplyOpcTDBRTotalIndex: Array[Byte] = Array(0.toByte)
   val totalSupplyOpc: List[Array[Byte]] = List(OpcId.opcTDBROpcTotal, OpcId.opcReturnValue)
-  val totalSupplyOpcIndex: List[Array[Byte]] = List(totalSupplyOpcTDBRTotalIndex, Array(1.toByte))
+  val totalSupplyOpcIndex: List[Array[Byte]] = List(totalSupplyOpcTDBRTotalIndex, Array(0.toByte))
 
-  val maxSupplyOpcTDBRMaxIndex: Array[Byte] = Array(DataStack.maxSupplyInput.tokenIndex, 1.toByte)
+  val maxSupplyOpcTDBRMaxIndex: Array[Byte] = Array(0.toByte)
   val maxSupplyOpc: List[Array[Byte]] = List(OpcId.opcTDBROpcMax, OpcId.opcReturnValue)
-  val maxSupplyOpcIndex: List[Array[Byte]] = List(maxSupplyOpcTDBRMaxIndex, Array(1.toByte))
+  val maxSupplyOpcIndex: List[Array[Byte]] = List(maxSupplyOpcTDBRMaxIndex, Array(0.toByte))
 
-  val balanceOfOpcTDBARBalanceIndex: Array[Byte] = Array(DataStack.balanceOfInput.accountIndex, DataStack.balanceOfInput.tokenIndex, 2.toByte)
+  val balanceOfOpcTDBARBalanceIndex: Array[Byte] = Array(DataStack.balanceOfInput.accountIndex, 1.toByte)
   val balanceOfOpc: List[Array[Byte]] = List(OpcId.opcTDBARBalance, OpcId.opcReturnValue)
-  val balanceOfOpcIndex: List[Array[Byte]] = List(balanceOfOpcTDBARBalanceIndex, Array(2.toByte))
+  val balanceOfOpcIndex: List[Array[Byte]] = List(balanceOfOpcTDBARBalanceIndex, Array(1.toByte))
 
   val getIssuerOpcCDBVRGetIndex: Array[Byte] = Array(StateVar.issuer, 0.toByte)
   val getIssuerOpc: List[Array[Byte]] = List(OpcId.opcCDBVRGet, OpcId.opcReturnValue)

--- a/src/test/scala/vsys/contract/TextualForm.scala
+++ b/src/test/scala/vsys/contract/TextualForm.scala
@@ -16,20 +16,20 @@ trait TextualForm {
     state <- stateVar
   } yield Seq(init, desc, state)
 
-  val stateVarTexture: Gen[Array[Byte]] = Gen.const(Deser.serializeArrays(TextualStateVar.stateVarName.map(x => Deser.serilizeString(x))))
-  val initializerTexture: Gen[Array[Byte]] = Gen.const(Deser.serializeArrays(Seq(TextureFun.initFuncBytes.sample.get)))
-  val descriptorTexture: Gen[Array[Byte]] = Gen.const(Deser.serializeArrays(Seq(TextureFun.supersedeFuncBytes.sample.get,
-    TextureFun.issueFuncBytes.sample.get, TextureFun.destroyFuncBytes.sample.get, TextureFun.splitFuncBytes.sample.get,
-    TextureFun.sendFuncBytes.sample.get, TextureFun.transferFuncBytes.sample.get, TextureFun.depositFuncBytes.sample.get,
-    TextureFun.withdrawFuncBytes.sample.get, TextureFun.totalSupplyFuncBytes.sample.get, TextureFun.maxSupplyFuncBytes.sample.get,
-    TextureFun.balanceOfFuncBytes.sample.get, TextureFun.getIssuerFuncBytes.sample.get)))
+  val stateVarTextual: Gen[Array[Byte]] = Gen.const(Deser.serializeArrays(TextualStateVar.stateVarName.map(x => Deser.serilizeString(x))))
+  val initializerTextual: Gen[Array[Byte]] = Gen.const(Deser.serializeArrays(Seq(TextualFun.initFuncBytes.sample.get)))
+  val descriptorTextual: Gen[Array[Byte]] = Gen.const(Deser.serializeArrays(Seq(TextualFun.supersedeFuncBytes.sample.get,
+    TextualFun.issueFuncBytes.sample.get, TextualFun.destroyFuncBytes.sample.get, TextualFun.splitFuncBytes.sample.get,
+    TextualFun.sendFuncBytes.sample.get, TextualFun.transferFuncBytes.sample.get, TextualFun.depositFuncBytes.sample.get,
+    TextualFun.withdrawFuncBytes.sample.get, TextualFun.totalSupplyFuncBytes.sample.get, TextualFun.maxSupplyFuncBytes.sample.get,
+    TextualFun.balanceOfFuncBytes.sample.get, TextualFun.getIssuerFuncBytes.sample.get)))
 
-  val textureRightGen: Gen[Seq[Array[Byte]]] = textureGen(initializerTexture, descriptorTexture, stateVarTexture)
+  val textualRightGen: Gen[Seq[Array[Byte]]] = textureGen(initializerTextual, descriptorTextual, stateVarTextual)
 
 }
 
-object TextureFun {
-  def textureFunGen(name: String, ret: Seq[String], para: Seq[String]): Gen[Array[Byte]] =  for {
+object TextualFun {
+  def textualFunGen(name: String, ret: Seq[String], para: Seq[String]): Gen[Array[Byte]] =  for {
     funcByte <- Gen.const(Deser.serializeArray(Deser.serilizeString(name)))
     returnByte <- Gen.const(Deser.serializeArray(Deser.serializeArrays(ret.map(x => Deser.serilizeString(x)))))
     paraByte <- Gen.const(Deser.serializeArrays(para.map(x => Deser.serilizeString(x))))
@@ -38,31 +38,31 @@ object TextureFun {
 
   val initPara: Seq[String] = Seq("max", "unity", "tokenDescription", "signer")
   val supersedePara: Seq[String] = Seq("newIssuer", "maker")
-  val issuePara: Seq[String] = Seq("amount", "tokenIndex", "issuer")
-  val destroyPara: Seq[String] = Seq("amount", "tokenIndex", "issuer")
-  val splitPara: Seq[String] = Seq("newUnity", "tokenIndex", "issuer")
-  val sendPara: Seq[String] = Seq("receipt", "amount", "tokenIndex", "caller")
-  val transferPara: Seq[String]= Seq("sender", "receipt", "amount", "tokenIndex")
-  val depositPara: Seq[String] = Seq("sender", "smart", "amount", "tokenIndex")
-  val withdrawPara: Seq[String]= Seq("smart", "receipt", "amount", "tokenIndex")
-  val totalSupplyPara: Seq[String] = Seq("tokenIndex", "total")
-  val maxSupplyPara: Seq[String] = Seq("tokenIndex", "max")
-  val balanceOfPara: Seq[String] = Seq("address", "tokenIndex", "balance")
+  val issuePara: Seq[String] = Seq("amount", "issuer")
+  val destroyPara: Seq[String] = Seq("amount", "issuer")
+  val splitPara: Seq[String] = Seq("newUnity", "issuer")
+  val sendPara: Seq[String] = Seq("receipt", "amount", "caller")
+  val transferPara: Seq[String]= Seq("sender", "receipt", "amount")
+  val depositPara: Seq[String] = Seq("sender", "smart", "amount")
+  val withdrawPara: Seq[String]= Seq("smart", "receipt", "amount")
+  val totalSupplyPara: Seq[String] = Seq("total")
+  val maxSupplyPara: Seq[String] = Seq("max")
+  val balanceOfPara: Seq[String] = Seq("address", "balance")
   val getIssuerPara: Seq[String] = Seq("issuer")
 
-  val initFuncBytes: Gen[Array[Byte]] = textureFunGen("init", Seq(), initPara)
-  val supersedeFuncBytes: Gen[Array[Byte]] = textureFunGen("supersede", Seq(), supersedePara)
-  val issueFuncBytes: Gen[Array[Byte]] = textureFunGen("issue", Seq(), issuePara)
-  val destroyFuncBytes: Gen[Array[Byte]] = textureFunGen("destroy", Seq(), destroyPara)
-  val splitFuncBytes: Gen[Array[Byte]] = textureFunGen("split", Seq(), splitPara)
-  val sendFuncBytes: Gen[Array[Byte]] = textureFunGen("send", Seq(), sendPara)
-  val transferFuncBytes: Gen[Array[Byte]] = textureFunGen("transfer", Seq(), transferPara)
-  val depositFuncBytes: Gen[Array[Byte]] = textureFunGen("deposit", Seq(), depositPara)
-  val withdrawFuncBytes: Gen[Array[Byte]] = textureFunGen("withdraw", Seq(), withdrawPara)
-  val totalSupplyFuncBytes: Gen[Array[Byte]] = textureFunGen("totalSupply", Seq("total"), totalSupplyPara)
-  val maxSupplyFuncBytes: Gen[Array[Byte]] = textureFunGen("maxSupply", Seq("max"), maxSupplyPara)
-  val balanceOfFuncBytes: Gen[Array[Byte]] = textureFunGen("balanceOf", Seq("balance"), balanceOfPara)
-  val getIssuerFuncBytes: Gen[Array[Byte]] = textureFunGen("getIssuer", Seq("issuer"), getIssuerPara)
+  val initFuncBytes: Gen[Array[Byte]] = textualFunGen("init", Seq(), initPara)
+  val supersedeFuncBytes: Gen[Array[Byte]] = textualFunGen("supersede", Seq(), supersedePara)
+  val issueFuncBytes: Gen[Array[Byte]] = textualFunGen("issue", Seq(), issuePara)
+  val destroyFuncBytes: Gen[Array[Byte]] = textualFunGen("destroy", Seq(), destroyPara)
+  val splitFuncBytes: Gen[Array[Byte]] = textualFunGen("split", Seq(), splitPara)
+  val sendFuncBytes: Gen[Array[Byte]] = textualFunGen("send", Seq(), sendPara)
+  val transferFuncBytes: Gen[Array[Byte]] = textualFunGen("transfer", Seq(), transferPara)
+  val depositFuncBytes: Gen[Array[Byte]] = textualFunGen("deposit", Seq(), depositPara)
+  val withdrawFuncBytes: Gen[Array[Byte]] = textualFunGen("withdraw", Seq(), withdrawPara)
+  val totalSupplyFuncBytes: Gen[Array[Byte]] = textualFunGen("totalSupply", Seq("total"), totalSupplyPara)
+  val maxSupplyFuncBytes: Gen[Array[Byte]] = textualFunGen("maxSupply", Seq("max"), maxSupplyPara)
+  val balanceOfFuncBytes: Gen[Array[Byte]] = textualFunGen("balanceOf", Seq("balance"), balanceOfPara)
+  val getIssuerFuncBytes: Gen[Array[Byte]] = textualFunGen("getIssuer", Seq("issuer"), getIssuerPara)
 }
 
 object TextualStateVar {

--- a/src/test/scala/vsys/state/diffs/ExecuteContractFunctionTransactionDiffTest.scala
+++ b/src/test/scala/vsys/state/diffs/ExecuteContractFunctionTransactionDiffTest.scala
@@ -38,7 +38,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     init <- triggerGen()
     descriptor <- descriptorFullGen()
     stateVar <- stateVarRandomGen()
-    textual <- textureRightGen
+    textual <- textualRightGen
   } yield (langCode, langVer, init, descriptor, stateVar, textual)
 
   property("execute contract build doesn't break invariant"){
@@ -50,7 +50,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
   val languageCode: String = "vdds"
   val languageVersion: Int = 1
 
-  val newValidContractTest: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newValidContractTest: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractTest: Gen[(GenesisTransaction, GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, Long)] = for {
     master <- accountGen
     user <- accountGen
@@ -65,11 +65,11 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     genesis2: GenesisTransaction = GenesisTransaction.create(user, ENOUGH_AMT, -1, ts).right.get
     feeEx: Long <- smallFeeGen
     descEx <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
-    splitData <- splitDataStackGen(1000, 0)
+    splitData <- splitDataStackGen(1000L)
     supersedeData <- supersedeDataStackGen(user.toAddress)
-    issueData <- issueDataStackGen(10000L, 0)
-    destoryData <- destroyDataStackGen(100L, 0)
-    sendData <- sendDataStackGen(master.toAddress, 500L, 0)
+    issueData <- issueDataStackGen(10000L)
+    destoryData <- destroyDataStackGen(100L)
+    sendData <- sendDataStackGen(master.toAddress, 500L)
     split: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, FunId.splitIndex, splitData, descEx, feeEx, feeScale, ts + 1).right.get
     supersede: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, FunId.supersedeIndex, supersedeData, descEx, feeEx, feeScale, ts + 2).right.get
     issue: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(user, regContract.contractId, FunId.issueIndex, issueData, descEx, feeEx, feeScale, ts + 3).right.get
@@ -115,7 +115,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newValidContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newValidContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractWithInvalidData: Gen[(GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction)] = for {
     master <- accountGen
     ts <- positiveLongGen
@@ -129,8 +129,8 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     feeEx: Long <- smallFeeGen
     rep <- mintingAddressGen
     descEx <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
-    dataForIssueDestorySplit: Seq[DataEntry] <- issueDataStackGen(10000L, 0)
-    dataForSend: Seq[DataEntry] <- sendDataStackGen(rep, 100L, 0)
+    dataForIssueDestorySplit: Seq[DataEntry] <- issueDataStackGen(10000L)
+    dataForSend: Seq[DataEntry] <- sendDataStackGen(rep, 100L)
     dataForSupersede: Seq[DataEntry] <- supersedeDataStackGen(rep)
     invalidData = dataForIssueDestorySplit ++ dataForSend
     invalidIssue: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, FunId.issueIndex, dataForSend, descEx, feeEx, feeScale, ts + 1000).right.get
@@ -168,7 +168,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractIssue: Gen[(GenesisTransaction, GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction)] = for {
     master <- accountGen
     invalidUser <- accountGen
@@ -182,9 +182,9 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     fee2: Long <- smallFeeGen
     funcIdx: Short <- Gen.const(FunId.issueIndex)
     description2 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
-    dataValid1: Seq[DataEntry] <- issueDataStackGen(10000L,0)
-    dataValid2: Seq[DataEntry] <- issueDataStackGen(99999999L,0)
-    dataFailed: Seq[DataEntry] <- issueDataStackGen(100000001L,0)
+    dataValid1: Seq[DataEntry] <- issueDataStackGen(10000L)
+    dataValid2: Seq[DataEntry] <- issueDataStackGen(99999999L)
+    dataFailed: Seq[DataEntry] <- issueDataStackGen(100000001L)
     genesis: GenesisTransaction = GenesisTransaction.create(master, ENOUGH_AMT, -1, ts).right.get
     genesis2: GenesisTransaction = GenesisTransaction.create(invalidUser, ENOUGH_AMT, -1, ts).right.get
     issueValid1: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, funcIdx, dataValid1, description2, fee2, feeScale, ts + 1).right.get
@@ -232,7 +232,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContractSend: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContractSend: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractSend: Gen[(GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction)] = for {
     master <- accountGen
     ts <- positiveIntGen
@@ -245,14 +245,14 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     fee1: Long <- smallFeeGen
     ts1: Long <- positiveLongGen
     funcIdx1: Short <- Gen.const(FunId.issueIndex)
-    data1: Seq[DataEntry] <- issueDataStackGen(100000L,0)
+    data1: Seq[DataEntry] <- issueDataStackGen(100000L)
     description1 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     recipient <- mintingAddressGen
     fee2: Long <- smallFeeGen
     ts2: Long <- positiveLongGen
     funcIdx2: Short <- Gen.const(FunId.sendIndex)
-    data2: Seq[DataEntry] <- sendDataStackGen(recipient, 100000L,0)
-    invalidData: Seq[DataEntry] <- sendDataStackGen(recipient, 1000000L,0)
+    data2: Seq[DataEntry] <- sendDataStackGen(recipient, 100000L)
+    invalidData: Seq[DataEntry] <- sendDataStackGen(recipient, 1000000L)
     description2 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     genesis: GenesisTransaction = GenesisTransaction.create(master, ENOUGH_AMT, -1, ts).right.get
     executeContractIssue: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, funcIdx1, data1, description1, fee1, feeScale, ts1).right.get
@@ -280,7 +280,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContractSupersede: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContractSupersede: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractSupersede: Gen[(GenesisTransaction, GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, Long)] = for {
     master <- accountGen
     newIssuer <- accountGen
@@ -294,7 +294,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     fee1: Long <- smallFeeGen
     ts1: Long <- positiveLongGen
     funcIdx1: Short <- Gen.const(FunId.issueIndex)
-    data1: Seq[DataEntry] <- issueDataStackGen(100000L,0)
+    data1: Seq[DataEntry] <- issueDataStackGen(100000L)
     description1 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     recipient <- mintingAddressGen
     fee2: Long <- smallFeeGen
@@ -324,7 +324,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContractSplit: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContractSplit: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractSplit: Gen[(GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, Long)] = for {
     master <- accountGen
     ts <- positiveIntGen
@@ -337,7 +337,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     fee2: Long <- smallFeeGen
     ts2: Long <- positiveLongGen
     funcIdx2: Short <- Gen.const(FunId.splitIndex)
-    data2: Seq[DataEntry] <- splitDataStackGen(10000L, 0)
+    data2: Seq[DataEntry] <- splitDataStackGen(10000L)
     description2 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     genesis: GenesisTransaction = GenesisTransaction.create(master, ENOUGH_AMT, -1, ts).right.get
     executeContractSplit: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, funcIdx2, data2, description2, fee2, feeScale, ts2).right.get
@@ -353,7 +353,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContractDestroy: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContractDestroy: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractDestroy: Gen[(GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction)] = for {
     master <- accountGen
     ts <- positiveIntGen
@@ -365,12 +365,12 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     regContract: RegisterContractTransaction = RegisterContractTransaction.create(master, contract, dataStack, description, fee, feeScale, ts).right.get
     fee1: Long <- smallFeeGen
     funcIdx1: Short <- Gen.const(FunId.issueIndex)
-    data1: Seq[DataEntry] <- issueDataStackGen(100000L,0)
+    data1: Seq[DataEntry] <- issueDataStackGen(100000L)
     description1 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     fee2: Long <- smallFeeGen
     funcIdx2: Short <- Gen.const(FunId.destroyIndex)
-    data2: Seq[DataEntry] <- destroyDataStackGen(10000L, 0)
-    invalidData: Seq[DataEntry] <- destroyDataStackGen(100001L, 0)
+    data2: Seq[DataEntry] <- destroyDataStackGen(10000L)
+    invalidData: Seq[DataEntry] <- destroyDataStackGen(100001L)
     description2 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     genesis: GenesisTransaction = GenesisTransaction.create(master, ENOUGH_AMT, -1, ts).right.get
     executeContractIssue: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, funcIdx1, data1, description1, fee1, feeScale, ts + 1000000L).right.get
@@ -398,7 +398,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContractTransfer: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContractTransfer: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractTransfer: Gen[(GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, Long)] = for {
     master <- accountGen
     ts <- positiveIntGen
@@ -412,13 +412,13 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     feeScale1: Short <- feeScaleGen
     ts1: Long <- positiveLongGen
     funcIdx1: Short <- Gen.const(FunId.issueIndex)
-    data1: Seq[DataEntry] <- issueDataStackGen(100000L,0)
+    data1: Seq[DataEntry] <- issueDataStackGen(100000L)
     recipient <- mintingAddressGen
     fee2: Long <- smallFeeGen
     feeScale2: Short <- feeScaleGen
     ts2: Long <- positiveLongGen
     funcIdx2: Short <- Gen.const(FunId.transferIndex)
-    data2: Seq[DataEntry] <- transferDataStackGen(PublicKeyAccount(master.publicKey).toAddress, recipient, 1000L,0)
+    data2: Seq[DataEntry] <- transferDataStackGen(PublicKeyAccount(master.publicKey).toAddress, recipient, 1000L)
     description1 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     genesis: GenesisTransaction = GenesisTransaction.create(master, ENOUGH_AMT, -1, ts).right.get
     executeContractIssue: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, funcIdx1, data1, description1, fee1, feeScale1, ts1).right.get
@@ -434,7 +434,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContractDeposit: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContractDeposit: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractDeposit: Gen[(GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, Long)] = for {
     master <- accountGen
     ts <- positiveIntGen
@@ -448,13 +448,13 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     feeScale1: Short <- feeScaleGen
     ts1: Long <- positiveLongGen
     funcIdx1: Short <- Gen.const(FunId.issueIndex)
-    data1: Seq[DataEntry] <- issueDataStackGen(100000L,0)
+    data1: Seq[DataEntry] <- issueDataStackGen(100000L)
     recipient <- mintingAddressGen
     fee2: Long <- smallFeeGen
     feeScale2: Short <- feeScaleGen
     ts2: Long <- positiveLongGen
     funcIdx2: Short <- Gen.const(FunId.depositIndex)
-    data2: Seq[DataEntry] <- depositDataStackGen(PublicKeyAccount(master.publicKey).toAddress, recipient, 1000L,0)
+    data2: Seq[DataEntry] <- depositDataStackGen(PublicKeyAccount(master.publicKey).toAddress, recipient, 1000L)
     description1 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     genesis: GenesisTransaction = GenesisTransaction.create(master, ENOUGH_AMT, -1, ts).right.get
     executeContractIssue: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, funcIdx1, data1, description1, fee1, feeScale1, ts1).right.get
@@ -470,7 +470,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContractWithdraw: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContractWithdraw: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractWithdraw: Gen[(GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, Long)] = for {
     master <- accountGen
     ts <- positiveIntGen
@@ -484,18 +484,18 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     feeScale1: Short <- feeScaleGen
     ts1: Long <- positiveLongGen
     funcIdx1: Short <- Gen.const(FunId.issueIndex)
-    data1: Seq[DataEntry] <- issueDataStackGen(100000L,0)
+    data1: Seq[DataEntry] <- issueDataStackGen(100000L)
     recipient <- mintingAddressGen
     fee2: Long <- smallFeeGen
     feeScale2: Short <- feeScaleGen
     ts2: Long <- positiveLongGen
-    data2: Seq[DataEntry] <- transferDataStackGen(PublicKeyAccount(master.publicKey).toAddress, recipient, 10000L,0)
+    data2: Seq[DataEntry] <- transferDataStackGen(PublicKeyAccount(master.publicKey).toAddress, recipient, 10000L)
     funcIdx2: Short <- Gen.const(FunId.transferIndex)
     fee3: Long <- smallFeeGen
     feeScale3: Short <- feeScaleGen
     ts3: Long <- positiveLongGen
     funcIdx3: Short <- Gen.const(FunId.withdrawIndex)
-    data3: Seq[DataEntry] <- withdrawDataStackGen(recipient, PublicKeyAccount(master.publicKey).toAddress, 1000L,0)
+    data3: Seq[DataEntry] <- withdrawDataStackGen(recipient, PublicKeyAccount(master.publicKey).toAddress, 1000L)
     description1 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     genesis: GenesisTransaction = GenesisTransaction.create(master, ENOUGH_AMT, -1, ts).right.get
     executeContractIssue: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, funcIdx1, data1, description1, fee1, feeScale1, ts1).right.get
@@ -512,7 +512,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContractTotalSupply: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContractTotalSupply: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractTotalSupply: Gen[(GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, Long)] = for {
     master <- accountGen
     ts <- positiveIntGen
@@ -526,13 +526,13 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     feeScale1: Short <- feeScaleGen
     ts1: Long <- positiveLongGen
     funcIdx1: Short <- Gen.const(FunId.issueIndex)
-    data1: Seq[DataEntry] <- issueDataStackGen(100000L,0)
+    data1: Seq[DataEntry] <- issueDataStackGen(100000L)
     recipient <- mintingAddressGen
     fee2: Long <- smallFeeGen
     feeScale2: Short <- feeScaleGen
     ts2: Long <- positiveLongGen
     funcIdx2: Short <- Gen.const(FunId.totalSupplyIndex)
-    data2: Seq[DataEntry] <- totalSupplyDataStackGen(0)
+    data2: Seq[DataEntry] <- emptyDataStackGen()
     description1 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     genesis: GenesisTransaction = GenesisTransaction.create(master, ENOUGH_AMT, -1, ts).right.get
     executeContractIssue: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, funcIdx1, data1, description1, fee1, feeScale1, ts1).right.get
@@ -548,7 +548,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContractMaxSupply: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContractMaxSupply: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractMaxSupply: Gen[(GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, Long)] = for {
     master <- accountGen
     ts <- positiveIntGen
@@ -562,13 +562,13 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     feeScale1: Short <- feeScaleGen
     ts1: Long <- positiveLongGen
     funcIdx1: Short <- Gen.const(FunId.issueIndex)
-    data1: Seq[DataEntry] <- issueDataStackGen(100000L,0)
+    data1: Seq[DataEntry] <- issueDataStackGen(100000L)
     recipient <- mintingAddressGen
     fee2: Long <- smallFeeGen
     feeScale2: Short <- feeScaleGen
     ts2: Long <- positiveLongGen
     funcIdx2: Short <- Gen.const(FunId.maxSupplyIndex)
-    data2: Seq[DataEntry] <- maxSupplyDataStackGen(0)
+    data2: Seq[DataEntry] <- emptyDataStackGen()
     description1 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     genesis: GenesisTransaction = GenesisTransaction.create(master, ENOUGH_AMT, -1, ts).right.get
     executeContractIssue: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, funcIdx1, data1, description1, fee1, feeScale1, ts1).right.get
@@ -584,7 +584,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContractBalanceOf: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContractBalanceOf: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractBalanceOf: Gen[(GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, Long)] = for {
     master <- accountGen
     ts <- positiveIntGen
@@ -598,13 +598,13 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     feeScale1: Short <- feeScaleGen
     ts1: Long <- positiveLongGen
     funcIdx1: Short <- Gen.const(FunId.issueIndex)
-    data1: Seq[DataEntry] <- issueDataStackGen(100000L,0)
+    data1: Seq[DataEntry] <- issueDataStackGen(100000L)
     recipient <- mintingAddressGen
     fee2: Long <- smallFeeGen
     feeScale2: Short <- feeScaleGen
     ts2: Long <- positiveLongGen
     funcIdx2: Short <- Gen.const(FunId.balanceOfIndex)
-    data2: Seq[DataEntry] <- balanceOfDataStackGen(PublicKeyAccount(master.publicKey).toAddress, 0)
+    data2: Seq[DataEntry] <- balanceOfDataStackGen(PublicKeyAccount(master.publicKey).toAddress)
     description1 <- genBoundedString(2, ExecuteContractFunctionTransaction.MaxDescriptionSize)
     genesis: GenesisTransaction = GenesisTransaction.create(master, ENOUGH_AMT, -1, ts).right.get
     executeContractIssue: ExecuteContractFunctionTransaction = ExecuteContractFunctionTransaction.create(master, regContract.contractId, funcIdx1, data1, description1, fee1, feeScale1, ts1).right.get
@@ -620,7 +620,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     }
   }
 
-  val newContractGetIssuer: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val newContractGetIssuer: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndExecuteContractGetIssuer: Gen[(GenesisTransaction, RegisterContractTransaction, ExecuteContractFunctionTransaction, ExecuteContractFunctionTransaction, Long)] = for {
     master <- accountGen
     ts <- positiveIntGen
@@ -634,7 +634,7 @@ class ExecuteContractFunctionTransactionDiffTest extends PropSpec
     feeScale1: Short <- feeScaleGen
     ts1: Long <- positiveLongGen
     funcIdx1: Short <- Gen.const(FunId.issueIndex)
-    data1: Seq[DataEntry] <- issueDataStackGen(100000L,0)
+    data1: Seq[DataEntry] <- issueDataStackGen(100000L)
     recipient <- mintingAddressGen
     fee2: Long <- smallFeeGen
     feeScale2: Short <- feeScaleGen

--- a/src/test/scala/vsys/state/diffs/RegisterContractTransactionDiffTest.scala
+++ b/src/test/scala/vsys/state/diffs/RegisterContractTransactionDiffTest.scala
@@ -37,7 +37,7 @@ class RegisterContractTransactionDiffTest extends PropSpec
     init <- triggerGen()
     descriptor <- descriptorFullGen()
     stateVar <- stateVarRandomGen()
-    textual <- textureRightGen
+    textual <- textualRightGen
   } yield (langCode, langVer, init, descriptor, stateVar, textual)
 
   property("register contract build doesn't break invariant"){
@@ -48,7 +48,7 @@ class RegisterContractTransactionDiffTest extends PropSpec
 
   val languageCode: String = "vdds"
   val languageVersion: Int = 1
-  val validContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val validContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndRegContractTest: Gen[(GenesisTransaction, RegisterContractTransaction)] = for {
     master <- accountGen
     ts <- positiveLongGen

--- a/src/test/scala/vsys/state/opcdiffs/RegisterContractTransactionOpcDiffTest.scala
+++ b/src/test/scala/vsys/state/opcdiffs/RegisterContractTransactionOpcDiffTest.scala
@@ -30,7 +30,7 @@ class RegisterContractTransactionOpcDiffTest extends PropSpec
   val languageCode: String = "vdds"
   val languageVersion: Int = 1
 
-  val regWrongParaContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerWrongParaGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val regWrongParaContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerWrongParaGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndRegContractWrongPara: Gen[(GenesisTransaction, RegisterContractTransaction, Long)] = for {
     master <- accountGen
     ts <- positiveLongGen
@@ -51,7 +51,7 @@ class RegisterContractTransactionOpcDiffTest extends PropSpec
     }
   }
 
-  val regContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val regContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndRegContract: Gen[(GenesisTransaction, RegisterContractTransaction, Long)] = for {
     master <- accountGen
     ts <- positiveLongGen
@@ -75,7 +75,7 @@ class RegisterContractTransactionOpcDiffTest extends PropSpec
     }
   }
 
-  val regWrongOpcFunContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerWrongTDBGen(), descriptorFullGen(), stateVarRightGen, textureRightGen)
+  val regWrongOpcFunContract: Gen[Contract] = contractNewGen(languageCode, languageVersion, triggerWrongTDBGen(), descriptorFullGen(), stateVarRightGen, textualRightGen)
   val preconditionsAndRegContractWrongFun: Gen[(GenesisTransaction, RegisterContractTransaction, Long)] = for {
     master <- accountGen
     ts <- positiveLongGen


### PR DESCRIPTION
1. Add overload token opc
2. modify contract permitted format
3. contract related unit tests
4. update contract translator