### PR TITLE
update time sync and add extra invalid execute contract unit test

### DIFF
--- a/src/main/scala/scorex/utils/Time.scala
+++ b/src/main/scala/scorex/utils/Time.scala
@@ -69,7 +69,7 @@ class TimeImpl extends Time with ScorexLogging with AutoCloseable {
       case Some((server, newOffset)) if !scheduler.isShutdown =>
         log.trace(s"Adjusting time with $newOffset nanoseconds, source: ${server.getHostAddress}.")
         offset = newOffset
-        val cntSysTime = System.currentTimeMillis()
+        val cntSysTime = correctedTime() / 1000000L
         val nextUpdateTime = (ExpirationTimeout - cntSysTime % ExpirationTimeout).toInt.milliseconds + 500.milliseconds
         // to avoid the miner mint time
         updateTask.delayExecution(nextUpdateTime)


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
1. update correct time sync rules, now we will update the time at in each 2 mins at a special time point (this can be changed)
2. add extra invalid execute contract function unit test

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
1. in original time update rule, system will sync the time every 100 seconds, however, in this case, minter may update a negative offset after the sync, then it may re-generate a new block. this block will not broadcast (will auto rejected by own node), but it will reduce the super-node efficiency.

two solutions:
- as the original way, only sync the time during `correctionTime()` called
- only sync the time at a periodic/special time point (easy, **chosen/implemented**)

2. some special transaction status need to be tested
## How Has This Been Tested

1. add new unit test
2. all unit test passed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
