### PR TITLE
add lease status

### DIFF
--- a/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
@@ -166,6 +166,8 @@ case class TransactionsApiRoute(
     tx.transaction match {
       case leaseCancel: LeaseCancelTransaction =>
         tx.json ++ Json.obj("lease" -> state.findTransaction[LeaseTransaction](leaseCancel.leaseId).map(_.json).getOrElse[JsValue](JsNull))
+      case lease: LeaseTransaction =>
+        tx.json ++ Json.obj("leaseStatus" -> (if (state.isLeaseActive(lease)) "active" else "canceled"))
       case _ => tx.json
     }
   }

--- a/src/main/scala/vsys/transaction/proof/EllipticCurve25519Proof.scala
+++ b/src/main/scala/vsys/transaction/proof/EllipticCurve25519Proof.scala
@@ -22,6 +22,7 @@ sealed trait EllipticCurve25519Proof extends Proof{
   lazy val json: JsObject = Json.obj(
     "proofType" -> proofType, // we can also write the detail name here
     "publicKey" -> Base58.encode(publicKey.publicKey),
+    "address" -> publicKey.address,
     "signature" -> signature.base58
   )
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
1. add lease status to transaction api (active or canceled)
2. add "address" to proof JSON

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
1. easy for api user to get the lease status
2. easy to get the sender address from the proof

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
all unit test passed

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Simple API change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
