### PR TITLE
bugfix/typo in BlockDiffer

### DIFF
--- a/src/main/scala/vsys/blockchain/state/diffs/BlockDiffer.scala
+++ b/src/main/scala/vsys/blockchain/state/diffs/BlockDiffer.scala
@@ -18,8 +18,8 @@ object BlockDiffer extends ScorexLogging {
 
   def right(diff: Diff): Either[ValidationError, Diff] = Right(diff)
 
-  def fromBlock(settings: FunctionalitySettings, s: StateReader,  pervBlockTimestamp : Option[Long])(block: Block): Either[ValidationError, BlockDiff] =
-    Signed.validateSignatures(block).flatMap { _ => apply(settings, s, pervBlockTimestamp)(block.feesDistribution, block.timestamp, block.transactionData, 1) }
+  def fromBlock(settings: FunctionalitySettings, s: StateReader,  prevBlockTimestamp : Option[Long])(block: Block): Either[ValidationError, BlockDiff] =
+    Signed.validateSignatures(block).flatMap { _ => apply(settings, s, prevBlockTimestamp)(block.feesDistribution, block.timestamp, block.transactionData, 1) }
 
   def unsafeDiffMany(settings: FunctionalitySettings, s: StateReader, prevBlockTimestamp: Option[Long])(blocks: Seq[Block]): BlockDiff =
     blocks.foldLeft((Monoid[BlockDiff].empty, prevBlockTimestamp)) { case ((diff, prev), block) =>
@@ -29,13 +29,13 @@ object BlockDiffer extends ScorexLogging {
 
   private def apply(settings: FunctionalitySettings,
                     s: StateReader,
-                    pervBlockTimestamp : Option[Long])(feesDistribution: Diff,
+                    prevBlockTimestamp : Option[Long])(feesDistribution: Diff,
                                                        timestamp: Long,
                                                        txs: Seq[ProcessedTransaction],
                                                        heightDiff: Int): Either[ValidationError, BlockDiff] = {
     val currentBlockHeight = s.height + 1
 
-    val txDiffer = TransactionDiffer(settings, pervBlockTimestamp, timestamp, currentBlockHeight) _
+    val txDiffer = TransactionDiffer(settings, prevBlockTimestamp, timestamp, currentBlockHeight) _
 
     // since we have some in block transactions with status not equal to success
     // we need a much stricter validation about fee charge in later version


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description
There are four typos in BlockDiffer.scala which should use `prevBlockTimeStamp` variable name for `pervBlockTimeStamp` variable name.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

None



## How Has This Been Tested
The changes have passed the unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
