### PR TITLE
Update build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,7 +165,6 @@ linuxScriptReplacements += "detect-loader" ->
     |""".stripMargin
 
 inConfig(Debian)(Seq(
-  debianPackageDependencies += "java8-runtime-headless",
   serviceAutostart := false,
   maintainerScripts := maintainerScriptsFromDirectory(packageSource.value / "debian", Seq("preinst", "postinst", "postrm", "prerm"))
 ))


### PR DESCRIPTION
# PR Details

remove line:

`debianPackageDependencies += "java8-runtime-headless",`

So we don't have to install like

`sudo dpkg --ignore-depends=java8-runtime-headless -i vsys_0.2.2_all.deb`

and can instead install like:

`sudo dpkg -i vsys_0.2.2_all.deb`

Since Oracle Java 8's tarball installation does not satisfy this dependency.

## Description

I removed the line declaring the dependency on java8-runtime-headless for our deb package so that we can cleanly install on Ubuntu 18.04 machines using Oracle JDK 8.

## Motivation and Context

This cleans up our documentation and makes our code reflect the reality that it's no longer possible to satisfy java8-runtime-headless with our chosen version of Java. 

## How Has This Been Tested

It has not been tested to my full satisfaction. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x]   Docs change / refactoring / dependency upgrade
-   [x]   Bug fix (non-breaking change which fixes an issue)
-   [ ]   New feature (non-breaking change which adds functionality)
-   [ ]   Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x]   My code follows the code style of this project.
-   [x]   My change requires a change to the documentation.
-   [ ]   I have updated the documentation accordingly.  
**I'll update docs after approval of this solution**
-   [ ]   I have added tests to cover my changes.
-   [ ]   All new and existing tests passed.
