### PR TITLE
Fix the returning type of Public key

### DIFF
--- a/src/main/scala/vsys/blockchain/contract/DataType.scala
+++ b/src/main/scala/vsys/blockchain/contract/DataType.scala
@@ -47,7 +47,7 @@ object DataType extends Enumeration {
     maxLen            = KeyLength,
     deserializer      = PublicKeyAccount(_),
     serializer        = p => p.publicKey,
-    jsonifier         = p => Json.toJson(p.address),
+    jsonifier         = p => Json.toJson(Base58.encode(p.publicKey)),
     extValidator      = _ => true)
 
   val Address         = DataTypeVal[vsys.account.Address](2,


### PR DESCRIPTION
# PR Details
API returning public key data bug fixed

## Description
Public key returned in api's endpoint '/contract/data/%s/%s' with publicKey db key returns public key instead of address

## Motivation and Context

To make API return with public key but not address

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ]   Docs change / refactoring / dependency upgrade
-   [x]   Bug fix (non-breaking change which fixes an issue)
-   [ ]   New feature (non-breaking change which adds functionality)
-   [ ]   Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x]   My code follows the code style of this project.
-   [x]   All new and existing tests passed.
