### PR TITLE
Contract/vswap prevent same token

### DIFF
--- a/src/main/scala/vsys/blockchain/contract/ContractVSwap.scala
+++ b/src/main/scala/vsys/blockchain/contract/ContractVSwap.scala
@@ -65,7 +65,7 @@ object ContractVSwap {
   val depositId: Short = 1
   val depositPara: Seq[String] = Seq("depositor", "amount", "tokenId") ++
                                  Seq("tokenAId", "tokenBId", "tokenLiquidityId", "isValidTokenId",
-                                     "isTokenA", "tokenAIfBlock", "isTokenB", "tokenBIfBlock",
+                                     "isTokenA", "valueFalse", "tokenAIfBlock", "isTokenB", "tokenBIfBlock",
                                      "isTokenLiquidity", "tokenLiquidityIfBlock")
   val depositDataType: Array[Byte] = Array(DataType.Address.id.toByte, DataType.Amount.id.toByte, DataType.TokenId.id.toByte)
   val depositTriggerOpcs: Seq[Array[Byte]] = Seq(
@@ -75,29 +75,33 @@ object ContractVSwap {
     cdbvrGet ++ Array(tokenLiquidityIdStateVar.index, 5.toByte),
     basicConstantGet ++ DataEntry(Array(0.toByte), DataType.Boolean).bytes ++ Array(6.toByte),
     compareBytesEqual ++ Array(2.toByte, 3.toByte, 7.toByte),
+    basicConstantGet ++ DataEntry(Array(0.toByte), DataType.Boolean).bytes ++ Array(8.toByte),
     basicConstantGet ++ DataEntry(genFunctionOpcs(
       Seq(
+        assertEqual ++ Array(6.toByte, 8.toByte),
         cdbvMapValAdd ++ Array(tokenABalanceMap.index, 0.toByte, 1.toByte),
         basicConstantGet ++ DataEntry(Array(1.toByte), DataType.Boolean).bytes ++ Array(6.toByte),
       )
-    ), DataType.OpcBlock).bytes ++ Array(8.toByte),
-    compareBytesEqual ++ Array(2.toByte, 4.toByte, 9.toByte),
+    ), DataType.OpcBlock).bytes ++ Array(9.toByte),
+    compareBytesEqual ++ Array(2.toByte, 4.toByte, 10.toByte),
     basicConstantGet ++ DataEntry(genFunctionOpcs(
       Seq(
+        assertEqual ++ Array(6.toByte, 8.toByte),
         cdbvMapValAdd ++ Array(tokenBBalanceMap.index, 0.toByte, 1.toByte),
         basicConstantGet ++ DataEntry(Array(1.toByte), DataType.Boolean).bytes ++ Array(6.toByte),
       )
-    ), DataType.OpcBlock).bytes ++ Array(10.toByte),
-    compareBytesEqual ++ Array(2.toByte, 5.toByte, 11.toByte),
+    ), DataType.OpcBlock).bytes ++ Array(11.toByte),
+    compareBytesEqual ++ Array(2.toByte, 5.toByte, 12.toByte),
     basicConstantGet ++ DataEntry(genFunctionOpcs(
       Seq(
+        assertEqual ++ Array(6.toByte, 8.toByte),
         cdbvMapValAdd ++ Array(liquidityBalanceMap.index, 0.toByte, 1.toByte),
         basicConstantGet ++ DataEntry(Array(1.toByte), DataType.Boolean).bytes ++ Array(6.toByte),
       )
-    ), DataType.OpcBlock).bytes ++ Array(12.toByte),
-    conditionIf ++ Array(7.toByte, 8.toByte),
-    conditionIf ++ Array(9.toByte, 10.toByte),
-    conditionIf ++ Array(11.toByte, 12.toByte),
+    ), DataType.OpcBlock).bytes ++ Array(13.toByte),
+    conditionIf ++ Array(7.toByte, 9.toByte),
+    conditionIf ++ Array(10.toByte, 11.toByte),
+    conditionIf ++ Array(12.toByte, 13.toByte),
     assertTrue ++ Array(6.toByte)
   )
   lazy val depositTrigger: Array[Byte] = getFunctionBytes(depositId, onDepositTriggerType, nonReturnType, depositDataType, depositTriggerOpcs)


### PR DESCRIPTION
# PR Details

Prevent users from depositing into V Swap contract if the input tokens are the same.

## Motivation and Context

There would be some strange behaviour if users are allowed to swap between the same token, or if the liquidity token is the same as the swappable tokens.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ]   Docs change / refactoring / dependency upgrade
-   [x]   Bug fix (non-breaking change which fixes an issue)
-   [ ]   New feature (non-breaking change which adds functionality)
-   [ ]   Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x]   My code follows the code style of this project.
-   [ ]   My change requires a change to the documentation.
-   [ ]   I have updated the documentation accordingly.
-   [x]   I have added tests to cover my changes.
-   [x]   All new and existing tests passed.
