### PR TITLE
update data entry type gen in atomic swap

### DIFF
--- a/src/test/scala/vsys/blockchain/contract/swap/AtomicSwapContractGen.scala
+++ b/src/test/scala/vsys/blockchain/contract/swap/AtomicSwapContractGen.scala
@@ -32,7 +32,7 @@ trait AtomicSwapContractGen extends SystemContractGen
                                 description: String, fee: Long, ts: Long): Gen[RegisterContractTransaction] =
     RegisterContractTransaction.create(signer, contract, dataStack, description, fee, feeScale, ts).explicitGet()
 
-  def lockAtomicSwapContractDataStackGen(signer: PrivateKeyAccount, contractId: ContractAccount, data: Seq[Array[Byte]], dataType: Seq[DataType.Value],
+  def lockAtomicSwapContractDataStackGen(signer: PrivateKeyAccount, contractId: ContractAccount, data: Seq[Array[Byte]], dataType: Seq[DataType.DataTypeVal[_]],
                                          attachment: Array[Byte], fee: Long, ts: Long): Gen[ExecuteContractFunctionTransaction] = {
     val id: Short = lockIndex
     for {
@@ -40,7 +40,7 @@ trait AtomicSwapContractGen extends SystemContractGen
     } yield ExecuteContractFunctionTransaction.create(signer, contractId, id, data, attachment, fee, feeScale, ts).explicitGet()
   }
 
-  def solvePuzzleAtomicSwapContractDataStackGen(signer: PrivateKeyAccount, contractId: ContractAccount, data: Seq[Array[Byte]], dataType: Seq[DataType.Value],
+  def solvePuzzleAtomicSwapContractDataStackGen(signer: PrivateKeyAccount, contractId: ContractAccount, data: Seq[Array[Byte]], dataType: Seq[DataType.DataTypeVal[_]],
                                                 attachment: Array[Byte], fee: Long, ts: Long): Gen[ExecuteContractFunctionTransaction] = {
     val id: Short = solvePuzzleIndex
     for {
@@ -48,7 +48,7 @@ trait AtomicSwapContractGen extends SystemContractGen
     } yield ExecuteContractFunctionTransaction.create(signer, contractId, id, data, attachment, fee, feeScale, ts).explicitGet()
   }
 
-  def expireWithdrawAtomicSwapContractDataStackGen(signer: PrivateKeyAccount, contractId: ContractAccount, data: Seq[Array[Byte]], dataType: Seq[DataType.Value],
+  def expireWithdrawAtomicSwapContractDataStackGen(signer: PrivateKeyAccount, contractId: ContractAccount, data: Seq[Array[Byte]], dataType: Seq[DataType.DataTypeVal[_]],
                                                    attachment: Array[Byte], fee: Long, ts: Long): Gen[ExecuteContractFunctionTransaction] = {
     val id: Short = expireWithdrawIndex
     for {

--- a/src/test/scala/vsys/blockchain/state/contract/swap/AtomicSwapContractDiffTest.scala
+++ b/src/test/scala/vsys/blockchain/state/contract/swap/AtomicSwapContractDiffTest.scala
@@ -195,7 +195,7 @@ class AtomicSwapContractDiffTest extends PropSpec
     deposit: ExecuteContractFunctionTransaction, lock: ExecuteContractFunctionTransaction, withdraw: ExecuteContractFunctionTransaction,
     withdrawVSYS: ExecuteContractFunctionTransaction, ts: Long, fee: Long) =>
       assertDiffAndStateCorrectBlockTime(Seq(TestBlock.create(genesis.timestamp, Seq(genesis, genesis2)), TestBlock.create(deposit.timestamp, Seq(reg, deposit))),
-        TestBlock.create(lock.timestamp + 101, Seq(lock, withdraw, withdrawVSYS))) { (blockDiff, newState) =>
+        TestBlock.create(lock.timestamp + 110, Seq(lock, withdraw, withdrawVSYS))) { (blockDiff, newState) =>
         blockDiff.txsDiff.txStatus shouldBe TransactionStatus.Success
         val totalPortfolioDiff: Portfolio = Monoid.combineAll(blockDiff.txsDiff.portfolios.values)
         totalPortfolioDiff.balance shouldBe -3 * fee


### PR DESCRIPTION
Data Entry type has changed in the exchange branch. This commit fixes the differences.
