### PR TITLE
Logback Version 1.2.9 Update Due to CVE-2021-42550 Vulnerability

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,7 +46,7 @@ object Dependencies {
   )
 
   lazy val logging = Seq(
-    "ch.qos.logback" % "logback-classic" % "1.2.3",
+    "ch.qos.logback" % "logback-classic" % "1.2.9",
     "org.slf4j" % "slf4j-api" % "1.7.25",
     "org.slf4j"            % "jul-to-slf4j"             % "1.7.25",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.11"


### PR DESCRIPTION
# PR Details

Logback Version 1.2.9 Update Due to CVE-2021-42550 Vulnerability

## Description

Upgrade logback version from 1.2.3 to 1.2.9 in Dependencies.scala

## Related Issue

X

## Motivation and Context
http://logback.qos.ch/news.html
see link above

## Types of changes
-   [x]   Docs change / refactoring / dependency upgrade


## Checklist
-   [x]   My code follows the code style of this project.

