### PR TITLE
Fix version  and depdency issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ enablePlugins(sbtdocker.DockerPlugin, JavaServerAppPackaging, JDebPackaging, Sys
 
 name := "vsys"
 organization := "systems.v"
-version := "0.4.0"
+version := "0.4.1"
 scalaVersion in ThisBuild := "2.12.6"
 crossPaths := false
 publishArtifact in (Compile, packageDoc) := false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers ++= Seq(
-  "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/",
+  "Typesafe repository" at "https://repo.scala-sbt.org",
   "Artima Maven Repository" at "https://repo.artima.com/releases",
   "JBoss" at "https://repository.jboss.org",
   Resolver.sbtPluginRepo("releases")


### PR DESCRIPTION
# PR Details

The typesafe repo no longer provide sevices and they seemed migraged to the "scala-sbt.org".  Potentaily because the bintray has stopped its services.
The current latest release had is "0.4.1". However in the build.sbt file the version is still 0.4.1. This will casues potential issue when building the docker image of vsystem. 
This pr fixes the both issues.

## Description

See above.

## Related Issue

Issue #311

## Motivation and Context

To be able to build the docker vsystem image.

## How Has This Been Tested

When try to run the `sbt packageAll`. It seems that it will had issue with the typesafe repo. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x]   Docs change / refactoring / dependency upgrade
-   [ ]   Bug fix (non-breaking change which fixes an issue)
-   [ ]   New feature (non-breaking change which adds functionality)
-   [ ]   Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x]   My code follows the code style of this project.
-   [ ]   My change requires a change to the documentation.
-   [ ]   I have updated the documentation accordingly.
-   [x]   I have added tests to cover my changes.
-   [ ]   All new and existing tests passed.
