### PR TITLE
Resolve sbt assembly deduplicate failure in packageAll

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,8 @@ libraryDependencies ++=
     "com.iheart" %% "ficus" % "1.4.3",
     ("org.scorexfoundation" %% "scrypto" % "1.2.2")
       .exclude("org.slf4j", "slf4j-api"),
-    "commons-net" % "commons-net" % "3.+",
+    "commons-net" % "commons-net" % "3.9.0",
+    "commons-io" % "commons-io" % "2.16.1",
     "org.typelevel" %% "cats-core" % "1.0.0-RC1",
     "io.monix" %% "monix" % "3.0.0-M2"
   )


### PR DESCRIPTION
# PR Details

Resolve sbt assembly deduplicate failure in node compiling.

## Description

Pin `commons-net` to 3.9.0 and add `commons-io` 2.16.1 so the fat-jar build no longer includes multi-release `module-info.class` duplicates. This keeps `sbt packageAll` from failing the merge phase with the commons artifacts that introduced Java 9 module descriptors.

## Related Issue
## Motivation and Context
`packageAll` failed with `deduplicate: different file contents` for `META-INF/versions/9/module-info.class` coming from `commons-net-3.12.0.jar` and `commons-io-2.20.0.jar`. Pinning lower versions that do not contribute conflicting descriptors lets sbt-assembly merge the dependencies cleanly.

## How Has This Been Tested
Tested locally

## Types of changes
-   [ ]   Docs change / refactoring / dependency upgrade
-   [x]   Bug fix (non-breaking change which fixes an issue)
-   [ ]   New feature (non-breaking change which adds functionality)
-   [ ]   Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
-   [x]   My code follows the code style of this project.
-   [ ]   My change requires a change to the documentation.
-   [ ]   I have updated the documentation accordingly.
-   [ ]   I have added tests to cover my changes.
-   [ ]   All new and existing tests passed.
